### PR TITLE
fix: windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "7.3.0"
+version = "8.0.0"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"
@@ -24,6 +24,7 @@ tokio = { version = "1.26.0", features = ["rt", "time"] }
 
 [dev-dependencies]
 axum-extra = { version = "0.7.0", features = ["cookie"] }
+local-ip-address = "0.5.1"
 regex = "1.8.1"
 serde-email = { version = "1.3.0", features = ["serde"] }
 tokio = { version = "1.26.0", features = ["rt", "rt-multi-thread", "time", "macros"] }

--- a/README.md
+++ b/README.md
@@ -51,10 +51,9 @@ This is primarily for testing Axum services.
 ### Runs on a random port, allowing multiple to run at once
 
 When you start the server, you can spin it up on a random port.
-Allowing you to run multiple servers in parallel.
+It allows multiple E2E tests to run in parallel, each on their own webserver.
 
-This is to allow multiple E2E tests to run in parallel.
-Each with their own webserver.
+This behaviour can be changed in the `TestServerConfig`, by selecting a custom ip or port to always use.
 
 ### Remembers cookies across requests
 

--- a/src/test_server_config.rs
+++ b/src/test_server_config.rs
@@ -1,4 +1,4 @@
-use ::std::net::SocketAddr;
+use ::std::net::IpAddr;
 
 /// The basic setup for the `TestServer`.
 #[derive(Debug, Clone)]
@@ -8,10 +8,15 @@ pub struct TestServerConfig {
     /// This overrides the default 'best efforts' approach of requests.
     pub default_content_type: Option<String>,
 
-    /// Set the socket to use for the server.
+    /// Set the IP to use for the server.
     ///
-    /// **Defaults** to a _random_ socket.
-    pub socket_address: Option<SocketAddr>,
+    /// **Defaults** to `127.0.0.1`.
+    pub ip: Option<IpAddr>,
+
+    /// Set the port number to use for the server.
+    ///
+    /// **Defaults** to a _random_ port.
+    pub port: Option<u16>,
 
     /// Set for the server to save cookies that are returned,
     /// for use in future requests.
@@ -27,7 +32,8 @@ impl Default for TestServerConfig {
     fn default() -> Self {
         Self {
             default_content_type: None,
-            socket_address: None,
+            ip: None,
+            port: None,
             save_cookies: false,
         }
     }

--- a/src/util/new_random_socket_addr.rs
+++ b/src/util/new_random_socket_addr.rs
@@ -5,11 +5,88 @@ use ::std::net::IpAddr;
 use ::std::net::Ipv4Addr;
 use ::std::net::SocketAddr;
 
-/// Generates a `SocketAddr` on the IP 0.0.0.0, using a random port.
+pub(crate) const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
+pub(crate) fn new_socket_addr_from_defaults(
+    maybe_ip: Option<IpAddr>,
+    maybe_port: Option<u16>,
+) -> Result<SocketAddr> {
+    let socket_addr = match (maybe_ip, maybe_port) {
+        (Some(ip), Some(port)) => SocketAddr::new(ip, port),
+        (None, Some(port)) => SocketAddr::new(DEFAULT_IP_ADDRESS, port),
+        (Some(ip), None) => SocketAddr::new(ip, new_random_port()?),
+        (None, None) => new_random_socket_addr()?,
+    };
+
+    Ok(socket_addr)
+}
+
+/// Generates a `SocketAddr` on the IP 127.0.0.1, using a random port.
 pub fn new_random_socket_addr() -> Result<SocketAddr> {
-    let ip_address = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
-    let port = pick_unused_port().ok_or_else(|| anyhow!("No free port was found"))?;
+    let ip_address = DEFAULT_IP_ADDRESS;
+    let port = new_random_port()?;
     let addr = SocketAddr::new(ip_address, port);
 
     Ok(addr)
+}
+
+/// Returns a randomly selected port that is not in use.
+pub fn new_random_port() -> Result<u16> {
+    let port = pick_unused_port().ok_or_else(|| anyhow!("No free port was found"))?;
+
+    Ok(port)
+}
+
+#[cfg(test)]
+mod test_new_socket_addr_from_defaults {
+    use super::*;
+    use ::regex::Regex;
+    use std::net::Ipv4Addr;
+    #[test]
+    fn it_should_create_default_ip_with_random_port_when_none() {
+        let ip = None;
+        let port = None;
+
+        let socket_addr = new_socket_addr_from_defaults(ip, port).unwrap();
+        let addr = format!("{}", socket_addr);
+
+        let regex = Regex::new("^127\\.0\\.0\\.1:[0-9]+$").unwrap();
+        let is_match = regex.is_match(&addr);
+        assert!(is_match);
+    }
+
+    #[test]
+    fn it_should_create_ip_with_random_port_when_ip_given() {
+        let ip = Some(IpAddr::V4(Ipv4Addr::new(123, 210, 7, 8)));
+        let port = None;
+
+        let socket_addr = new_socket_addr_from_defaults(ip, port).unwrap();
+        let addr = format!("{}", socket_addr);
+
+        let regex = Regex::new("^123\\.210\\.7\\.8:[0-9]+$").unwrap();
+        let is_match = regex.is_match(&addr);
+        assert!(is_match);
+    }
+
+    #[test]
+    fn it_should_create_default_ip_with_port_when_port_given() {
+        let ip = None;
+        let port = Some(123);
+
+        let socket_addr = new_socket_addr_from_defaults(ip, port).unwrap();
+        let addr = format!("{}", socket_addr);
+
+        assert_eq!(addr, "127.0.0.1:123");
+    }
+
+    #[test]
+    fn it_should_create_ip_port_given_when_both_given() {
+        let ip = Some(IpAddr::V4(Ipv4Addr::new(123, 210, 7, 8)));
+        let port = Some(123);
+
+        let socket_addr = new_socket_addr_from_defaults(ip, port).unwrap();
+        let addr = format!("{}", socket_addr);
+
+        assert_eq!(addr, "123.210.7.8:123");
+    }
 }


### PR DESCRIPTION
# Changes

 * Change default IP address from `0.0.0.0` to `127.0.0.1`.
 * Add means to change defautt IP.
 * Add means to change default Port.
 * Remove default socket address.
 * Bump to version 8.

# Comments

This fixes Windows support, and if needed by the user, gives the ability to set _only_ the IP to use.

