### PR TITLE
assert 2xx rather than 200

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ and then included into the next request. Like a web browser.
 
 ### Fails fast on unexpected requests
 
-By default; all requests will panic if the server fails to return a 200.
-This can be switched to panic when the server _doesn't_ return a 200.
+By default; all requests will panic if the server fails to return a 2xx status code.
+This [can be switched](https://docs.rs/axum-test/latest/axum_test/struct.TestRequest.html#method.expect_failure) to panic when the server _doesn't_ return a 200.
 
 This is a very opinionated design choice, and is done to help test writers fail fast when writing tests.

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -259,7 +259,7 @@ impl TestRequest {
         if self.is_expecting_failure {
             response = response.assert_status_not_ok();
         } else {
-            response = response.assert_status_ok();
+            response = response.assert_status_success();
         }
 
         Ok(response)

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -144,7 +144,7 @@ impl TestRequest {
     }
 
     /// Marks that this request should expect to succeed.
-    /// Success is deemend as returning a 200.
+    /// Success is deemend as returning a 2xx status code.
     ///
     /// Note this is the default behaviour when creating a new `TestRequest`.
     pub fn expect_success(mut self) -> Self {

--- a/src/test_request_future.rs
+++ b/src/test_request_future.rs
@@ -202,7 +202,7 @@ impl Future for TestRequestFuture {
                             if self.is_expecting_failure {
                                 test_response = test_response.assert_status_not_ok();
                             } else {
-                                test_response = test_response.assert_status_ok();
+                                test_response = test_response.assert_status_success();
                             }
 
                             return Poll::Ready(test_response);

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -205,6 +205,7 @@ impl TestResponse {
 
     /// This performs an assertion comparing the whole body of the response,
     /// against the text provided.
+    #[track_caller]
     pub fn assert_text<C>(self, other: C) -> Self
     where
         C: AsRef<str>,
@@ -223,6 +224,7 @@ impl TestResponse {
     /// Other can be your own Serde model that you wish to deserialise
     /// the data into, or it can be a `json!` blob created using
     /// the `::serde_json::json` macro.
+    #[track_caller]
     pub fn assert_json<T>(self, other: &T) -> Self
     where
         for<'de> T: Deserialize<'de> + PartialEq<T> + Debug,
@@ -233,28 +235,49 @@ impl TestResponse {
         self
     }
 
+    /// Assert the response status code is 400
+    #[track_caller]
     pub fn assert_status_bad_request(self) -> Self {
         self.assert_status(StatusCode::BAD_REQUEST)
     }
 
+    /// Assert the response status code is 404
+    #[track_caller]
     pub fn assert_status_not_found(self) -> Self {
         self.assert_status(StatusCode::NOT_FOUND)
     }
 
+    /// Assert the response status code is 200
+    #[track_caller]
     pub fn assert_status_ok(self) -> Self {
         self.assert_status(StatusCode::OK)
     }
 
+    /// Assert the response status code is 200-299
+    #[track_caller]
+    pub fn assert_status_success(self) -> Self {
+        assert!(
+            self.status_code.is_success(),
+            "expected status code to be 2xx, got {}",
+            self.status_code
+        );
+        self
+    }
+
+    /// Assert the response status code is _not_ 200
+    #[track_caller]
     pub fn assert_status_not_ok(self) -> Self {
         self.assert_not_status(StatusCode::OK)
     }
 
+    #[track_caller]
     pub fn assert_status(self, status_code: StatusCode) -> Self {
         assert_eq!(self.status_code(), status_code);
 
         self
     }
 
+    #[track_caller]
     pub fn assert_not_status(self, status_code: StatusCode) -> Self {
         assert_ne!(self.status_code(), status_code);
 


### PR DESCRIPTION
Makes the success check more permissive by default, allowing any status code in the 2xx range, rather than just 200. 

After making this change I did see https://github.com/JosephLenton/axum-test/compare/main...fix-200-fail-status, and so some of this change is redundant, though I think the combination of the two branches is better than either alone.