### PR TITLE
fix: 200 fail status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "8.1.0"
+version = "9.0.0"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ and then included into the next request. Like a web browser.
 
 ### Fails fast on unexpected requests
 
-By default; all requests will panic if the server fails to return a 200.
-This can be switched to panic when the server _doesn't_ return a 200.
+By default; all requests will panic if the server fails to return a 2xx status code.
+This [can be switched](https://docs.rs/axum-test/latest/axum_test/struct.TestRequest.html#method.expect_failure) to panic when the server _doesn't_ return a 200.
 
 This is a very opinionated design choice, and is done to help test writers fail fast when writing tests.

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -307,9 +307,7 @@ mod test_expect_success {
         let server = TestServer::new(app).expect("Should create test server");
 
         // Get the request.
-        server.get(&"/ping")
-            .expect_success()
-            .await;
+        server.get(&"/ping").expect_success().await;
     }
 
     #[tokio::test]
@@ -327,26 +325,20 @@ mod test_expect_success {
         let server = TestServer::new(app).expect("Should create test server");
 
         // Get the request.
-        server.get(&"/accepted")
-            .expect_success()
-            .await;
+        server.get(&"/accepted").expect_success().await;
     }
 
     #[tokio::test]
     #[should_panic]
     async fn it_should_panic_on_404() {
         // Build an application with a route.
-        let app = Router::new()
-            .into_make_service();
+        let app = Router::new().into_make_service();
 
         // Run the server.
         let server = TestServer::new(app).expect("Should create test server");
 
         // Get the request.
-        server
-            .get(&"/some_unknown_route")
-            .expect_success()
-            .await;
+        server.get(&"/some_unknown_route").expect_success().await;
     }
 }
 
@@ -368,10 +360,7 @@ mod test_expect_failure {
         let server = TestServer::new(app).expect("Should create test server");
 
         // Get the request.
-        server
-            .get(&"/some_unknown_route")
-            .expect_failure()
-            .await;
+        server.get(&"/some_unknown_route").expect_failure().await;
     }
 
     #[tokio::test]
@@ -390,9 +379,7 @@ mod test_expect_failure {
         let server = TestServer::new(app).expect("Should create test server");
 
         // Get the request.
-        server.get(&"/ping")
-            .expect_failure()
-            .await;
+        server.get(&"/ping").expect_failure().await;
     }
 
     #[tokio::test]
@@ -411,8 +398,6 @@ mod test_expect_failure {
         let server = TestServer::new(app).expect("Should create test server");
 
         // Get the request.
-        server.get(&"/accepted")
-            .expect_failure()
-            .await;
+        server.get(&"/accepted").expect_failure().await;
     }
 }

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -205,6 +205,7 @@ impl TestResponse {
 
     /// This performs an assertion comparing the whole body of the response,
     /// against the text provided.
+    #[track_caller]
     pub fn assert_text<C>(&self, other: C)
     where
         C: AsRef<str>,
@@ -221,6 +222,7 @@ impl TestResponse {
     /// Other can be your own Serde model that you wish to deserialise
     /// the data into, or it can be a `json!` blob created using
     /// the `::serde_json::json` macro.
+    #[track_caller]
     pub fn assert_json<T>(&self, other: &T)
     where
         for<'de> T: Deserialize<'de> + PartialEq<T> + Debug,
@@ -229,36 +231,50 @@ impl TestResponse {
         assert_eq!(own_json, *other);
     }
 
-    /// This will panic if the status code is **outside** the 2xx range.
+    /// This will panic if the status code is **within** the 2xx range.
+    /// i.e. The range from 200-299.
+    #[track_caller]
     pub fn assert_status_success(&self) {
         assert!(200 <= self.status_code.as_u16() && self.status_code.as_u16() <= 299);
     }
 
-    /// This will panic if the status code is **within** the 2xx range.
+    /// This will panic if the status code is **outside** the 2xx range.
+    /// i.e. A status code less than 200, or 300 or more.
+    #[track_caller]
     pub fn assert_status_failure(&self) {
         assert!(self.status_code.as_u16() < 200 || 299 < self.status_code.as_u16());
     }
 
+    /// Assert the response status code is 400.
+    #[track_caller]
     pub fn assert_status_bad_request(&self) {
         self.assert_status(StatusCode::BAD_REQUEST)
     }
 
+    /// Assert the response status code is 404.
+    #[track_caller]
     pub fn assert_status_not_found(&self) {
         self.assert_status(StatusCode::NOT_FOUND)
     }
 
+    /// Assert the response status code is 200.
+    #[track_caller]
     pub fn assert_status_ok(&self) {
         self.assert_status(StatusCode::OK)
     }
 
+    /// Assert the response status code is **not** 200.
+    #[track_caller]
     pub fn assert_status_not_ok(&self) {
         self.assert_not_status(StatusCode::OK)
     }
 
+    #[track_caller]
     pub fn assert_status(&self, status_code: StatusCode) {
         assert_eq!(self.status_code(), status_code);
     }
 
+    #[track_caller]
     pub fn assert_not_status(&self, status_code: StatusCode) {
         assert_ne!(self.status_code(), status_code);
     }

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -229,6 +229,16 @@ impl TestResponse {
         assert_eq!(own_json, *other);
     }
 
+    /// This will panic if the status code is **outside** the 2xx range.
+    pub fn assert_status_success(&self) {
+        assert!(200 <= self.status_code.as_u16() && self.status_code.as_u16() <= 299);
+    }
+
+    /// This will panic if the status code is **within** the 2xx range.
+    pub fn assert_status_failure(&self) {
+        assert!(self.status_code.as_u16() < 200 || 299 < self.status_code.as_u16());
+    }
+
     pub fn assert_status_bad_request(&self) {
         self.assert_status(StatusCode::BAD_REQUEST)
     }


### PR DESCRIPTION
# Changes

 * Change default expect behaviour to expect 2xx range or not, rather than 200 alone.
 * Add `#[track_caller]` to assert functions.
