### PR TITLE
Added support for adding arbitrary header to a `TestRequest`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,3 +549,65 @@ mod test_cookies {
         assert_eq!(response_text, "my-custom-cookie");
     }
 }
+
+#[cfg(test)]
+mod test_custom_headers {
+    use super::*;
+
+    use ::axum::async_trait;
+    use ::axum::extract::FromRequestParts;
+    use ::axum::routing::get;
+    use ::axum::Router;
+    use ::hyper::http::request::Parts;
+    use ::hyper::http::HeaderName;
+    use ::hyper::StatusCode;
+    use hyper::http::HeaderValue;
+
+    const TEST_HEADER_NAME: &'static str = &"test-header";
+    const TEST_HEADER_CONTENT: &'static str = &"Test header content";
+
+    struct TestHeader(Vec<u8>);
+
+    #[async_trait]
+    impl<S> FromRequestParts<S> for TestHeader {
+        type Rejection = (StatusCode, &'static str);
+
+        async fn from_request_parts(
+            parts: &mut Parts,
+            state: &S,
+        ) -> Result<TestHeader, Self::Rejection> {
+            parts
+                .headers
+                .get(HeaderName::from_static(TEST_HEADER_NAME))
+                .map(|v| TestHeader(v.as_bytes().to_vec()))
+                .ok_or((StatusCode::BAD_REQUEST, "Missing test header"))
+        }
+    }
+
+    async fn ping_header(TestHeader(header): TestHeader) -> Vec<u8> {
+        header
+    }
+
+    #[tokio::test]
+    async fn it_should_send_the_header() {
+        // Build an application with a route.
+        let app = Router::new()
+            .route("/header", get(ping_header))
+            .into_make_service();
+
+        // Run the server.
+        let server = TestServer::new(app).expect("Should create test server");
+
+        // Send a request with the header
+        let response = server
+            .get(&"/header")
+            .add_header(
+                HeaderName::from_static(TEST_HEADER_NAME),
+                HeaderValue::from_static(TEST_HEADER_CONTENT),
+            )
+            .await;
+
+        // Check it sent back the right text
+        response.assert_text(TEST_HEADER_CONTENT)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,8 +560,8 @@ mod test_custom_headers {
     use ::axum::Router;
     use ::hyper::http::request::Parts;
     use ::hyper::http::HeaderName;
+    use ::hyper::http::HeaderValue;
     use ::hyper::StatusCode;
-    use hyper::http::HeaderValue;
 
     const TEST_HEADER_NAME: &'static str = &"test-header";
     const TEST_HEADER_CONTENT: &'static str = &"Test header content";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,7 +574,7 @@ mod test_custom_headers {
 
         async fn from_request_parts(
             parts: &mut Parts,
-            state: &S,
+            _state: &S,
         ) -> Result<TestHeader, Self::Rejection> {
             parts
                 .headers

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -21,7 +21,6 @@ use ::std::fmt::Display;
 use ::std::future::IntoFuture;
 use ::std::sync::Arc;
 use ::std::sync::Mutex;
-use serde_json::value;
 
 use crate::ServerSharedState;
 use crate::TestResponse;

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -21,6 +21,7 @@ use ::std::fmt::Display;
 use ::std::future::IntoFuture;
 use ::std::sync::Arc;
 use ::std::sync::Mutex;
+use serde_json::value;
 
 use crate::ServerSharedState;
 use crate::TestResponse;
@@ -131,6 +132,18 @@ impl TestRequest {
     /// Adds a Cookie to be sent with this request.
     pub fn add_cookie<'c>(mut self, cookie: Cookie<'c>) -> Self {
         self.cookies.add(cookie.into_owned());
+        self
+    }
+
+    /// Clears all headers set.
+    pub fn clear_headers(mut self) -> Self {
+        self.headers = vec![];
+        self
+    }
+
+    /// Adds a header to be sent with this request.
+    pub fn add_header<'c>(mut self, name: HeaderName, value: HeaderValue) -> Self {
+        self.headers.push((name, value));
         self
     }
 


### PR DESCRIPTION
# Changes

 * Added builder methods `add_header` and `clear_headers` to the struct `TestRequest`

# Comments

Fixes #12 
In case of duplicate headers (e.g. setting the `content-type`) the last ones take precedence. I think this is the less surprising outcome, although maybe it is better to substitute `TestRequest.headers` with some map.

