### PR TITLE
Feat http requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ axum = "0.6.10"
 anyhow = "1.0.69"
 cookie = "0.17.0"
 hyper = { version = "0.14.24", features = ["client", "http1"] }
+lazy_static = "1.4.0"
 portpicker = "0.1.1"
+regex = "1.8.4"
 serde = { version = "1.0.152" }
 serde_json = "1.0.93"
 tokio = { version = "1.26.0", features = ["rt", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "9.1.1"
+version = "10.0.0"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -236,7 +236,11 @@ impl TestResponse {
     #[track_caller]
     pub fn assert_status_success(&self) {
         let status_code = self.status_code.as_u16();
-        assert!(200 <= status_code && status_code <= 299, "Expect status code _within_ 2xx range, got {}", status_code);
+        assert!(
+            200 <= status_code && status_code <= 299,
+            "Expect status code _within_ 2xx range, got {}",
+            status_code
+        );
     }
 
     /// This will panic if the status code is **outside** the 2xx range.
@@ -244,7 +248,11 @@ impl TestResponse {
     #[track_caller]
     pub fn assert_status_failure(&self) {
         let status_code = self.status_code.as_u16();
-        assert!(status_code < 200 || 299 < status_code, "Expect status code _outside_ 2xx range, got {}", status_code);
+        assert!(
+            status_code < 200 || 299 < status_code,
+            "Expect status code _outside_ 2xx range, got {}",
+            status_code
+        );
     }
 
     /// Assert the response status code is 400.
@@ -284,10 +292,10 @@ impl TestResponse {
 
 #[cfg(test)]
 mod test_assert_success {
-    use ::axum::http::StatusCode;
-    use ::axum::routing::Router;
-    use ::axum::routing::get;
     use crate::TestServer;
+    use ::axum::http::StatusCode;
+    use ::axum::routing::get;
+    use ::axum::routing::Router;
 
     pub async fn route_get_pass() -> StatusCode {
         StatusCode::OK
@@ -303,14 +311,9 @@ mod test_assert_success {
             .route(&"/pass", get(route_get_pass))
             .route(&"/fail", get(route_get_fail));
 
-        let server = TestServer::new(
-            router.into_make_service()
-        )
-        .unwrap();
+        let server = TestServer::new(router.into_make_service()).unwrap();
 
-        let response = server
-            .get(&"/pass")
-            .await;
+        let response = server.get(&"/pass").await;
 
         response.assert_status_success()
     }
@@ -322,15 +325,9 @@ mod test_assert_success {
             .route(&"/pass", get(route_get_pass))
             .route(&"/fail", get(route_get_fail));
 
-        let server = TestServer::new(
-            router.into_make_service()
-        )
-        .unwrap();
+        let server = TestServer::new(router.into_make_service()).unwrap();
 
-        let response = server
-            .get(&"/fail")
-            .expect_failure()
-            .await;
+        let response = server.get(&"/fail").expect_failure().await;
 
         response.assert_status_success()
     }
@@ -338,10 +335,10 @@ mod test_assert_success {
 
 #[cfg(test)]
 mod test_assert_failure {
-    use ::axum::http::StatusCode;
-    use ::axum::routing::Router;
-    use ::axum::routing::get;
     use crate::TestServer;
+    use ::axum::http::StatusCode;
+    use ::axum::routing::get;
+    use ::axum::routing::Router;
 
     pub async fn route_get_pass() -> StatusCode {
         StatusCode::OK
@@ -357,15 +354,9 @@ mod test_assert_failure {
             .route(&"/pass", get(route_get_pass))
             .route(&"/fail", get(route_get_fail));
 
-        let server = TestServer::new(
-            router.into_make_service()
-        )
-        .unwrap();
+        let server = TestServer::new(router.into_make_service()).unwrap();
 
-        let response = server
-            .get(&"/fail")
-            .expect_failure()
-            .await;
+        let response = server.get(&"/fail").expect_failure().await;
 
         response.assert_status_failure()
     }
@@ -377,14 +368,9 @@ mod test_assert_failure {
             .route(&"/pass", get(route_get_pass))
             .route(&"/fail", get(route_get_fail));
 
-        let server = TestServer::new(
-            router.into_make_service()
-        )
-        .unwrap();
+        let server = TestServer::new(router.into_make_service()).unwrap();
 
-        let response = server
-            .get(&"/pass")
-            .await;
+        let response = server.get(&"/pass").await;
 
         response.assert_status_failure()
     }

--- a/src/test_server_config.rs
+++ b/src/test_server_config.rs
@@ -26,6 +26,22 @@ pub struct TestServerConfig {
     ///
     /// **Defaults** to false (being turned off).
     pub save_cookies: bool,
+
+    /// If you make a request with a 'http://' schema,
+    /// then it will ignore the Test Server's address.
+    ///
+    /// For example if the test server is running at `http://localhost:1234`,
+    /// and you make a request to `http://google.com`.
+    /// Then the request will go to `http://google.com`.
+    /// Ignoring the `localhost:1234` part.
+    ///
+    /// Turning this setting on will change this behaviour.
+    ///
+    /// After turning this on, the same request will go to
+    /// `http://localhost:1234/http://google.com`.
+    ///
+    /// **Defaults** to false (being turned off).
+    pub restrict_requests_with_http_schema: bool,
 }
 
 impl Default for TestServerConfig {
@@ -35,6 +51,7 @@ impl Default for TestServerConfig {
             ip: None,
             port: None,
             save_cookies: false,
+            restrict_requests_with_http_schema: false,
         }
     }
 }


### PR DESCRIPTION
# Changes

 * Allow requests that include the full http schema, to bypass the TestServer.

# Comments

This is needed for a real world E2E test.
