### PR TITLE
change: default expect failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,8 @@
   [![docs](https://docs.rs/axum-test/badge.svg)](https://docs.rs/axum-test)
 </div>
 
-This is a project to make it easier to test applications built using Axum.
-Using full E2E tests.
-
-Some of the design decisions behind this are very opinionated,
-to encourage one to write good tests.
+This is a project to make it easier to test applications built using Axum,
+using full E2E tests.
 
 ## Examples
 
@@ -20,8 +17,8 @@ You can find a thorough example in the [/examples folder](/examples/example-todo
 
 ## Features
 
-This is for spinning up an Axum service, that you can then query directly.
-This is primarily for testing Axum services.
+You can start a webserver running your application, query it with requests,
+and then assert the responses returned:
 
 ```rust
   use ::axum::Router;
@@ -52,22 +49,26 @@ This is primarily for testing Axum services.
   }
 ```
 
-### Runs on a random port, allowing multiple to run at once
-
-When you start the server, you can spin it up on a random port.
-It allows multiple E2E tests to run in parallel, each on their own webserver.
+The `TestServer` will start on a random port, allowing multiple servers to run in parallel.
+That allows tests to be run in parallel.
 
 This behaviour can be changed in the `TestServerConfig`, by selecting a custom ip or port to always use.
 
+### Request building
+
+Querying your application on the `TestServer` supports all of the common request building you would expect.
+
+ - Serlializing and deserializing Json and Form content using Serde
+ - Cookie setting and reading
+ - Access to setting and reading headers
+ - Status code reading and assertions
+ - Assertions for defining what you expect to have returned
+
 ### Remembers cookies across requests
 
-It is common in E2E tests that step 1 is to login, and step 2 is the main request.
-To make this easier cookies returned from the server will be preserved,
-and then included into the next request. Like a web browser.
+`axum-test` supports preserving Cookies from responses,
+for use in follow up requests to same `TestServer`.
+This is similar to how a browser will store cookies from requests,
+and can help with tests where you need to authenticate first.
 
-### Fails fast on unexpected requests
-
-By default; all requests will panic if the server fails to return a 2xx status code.
-This [can be switched](https://docs.rs/axum-test/latest/axum_test/struct.TestRequest.html#method.expect_failure) to panic when the server _doesn't_ return a 200.
-
-This is a very opinionated design choice, and is done to help test writers fail fast when writing tests.
+This is _off_ by default, and can be enabled in the `TestServerConfig` by setting `save_cookies` to true.

--- a/examples/example-todo/main.rs
+++ b/examples/example-todo/main.rs
@@ -176,6 +176,7 @@ fn new_test_app() -> TestServer {
             // Preserve cookies across requests
             // for the session cookie to work.
             save_cookies: true,
+            expect_success_by_default: true,
             ..TestServerConfig::default()
         },
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,11 +279,7 @@ mod test_get {
 
         // Get the request.
         let absolute_url = format!("http://{ip}:{port}/ping");
-        server
-            .get(&absolute_url)
-            .expect_failure()
-            .await
-            .assert_status_not_found();
+        server.get(&absolute_url).await.assert_status_not_found();
     }
 }
 

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -50,14 +50,10 @@ const TEXT_CONTENT_TYPE: &'static str = &"text/plain";
 ///
 /// The `TestRequest` allows the caller to fill in the rest of the request
 /// to be sent to the server. Including the headers, the body, cookies,
-/// and content type.
-///
-/// For example to send a JSON request:
-///
+/// and the content type, using the relevant functions.
 ///
 /// The TestRequest struct provides a number of methods to set up the request,
 /// such as json, text, bytes, expect_failure, content_type, etc.
-/// The do_save_cookies and do_not_save_cookies methods are used to control cookie handling.
 ///
 /// ## Sending
 ///
@@ -69,6 +65,15 @@ const TEXT_CONTENT_TYPE: &'static str = &"text/plain";
 /// ```
 ///
 /// You will receive back a `TestResponse`.
+///
+/// ## Cookie Saving
+///
+/// [`crate::TestRequest::do_save_cookies'] and [`crate::TestRequest::do_not_save_cookies']
+/// methods allow you to set the request to save cookies to the `TestServer`,
+/// for reuse on any future requests.
+///
+/// This behaviour is **off** by default, and can be changed for all `TestRequests`
+/// when building the `TestServer`. By building it with a `TestServerConfig` where `save_cookies` is set to true.
 ///
 /// ## Expecting Failure and Success
 ///
@@ -323,21 +328,53 @@ impl TestRequest {
         self
     }
 
-    /// Marks that this request should expect to fail.
-    /// Failiure is deemend as any response that isn't a 200.
+    /// Marks that this request is expected to always return a HTTP
+    /// status code within the 2xx range (200 to 299).
     ///
-    /// By default, requests are expct to always succeed.
-    pub fn expect_failure(mut self) -> Self {
-        self.is_expecting_success = Some(false);
+    /// If a code _outside_ of that range is returned,
+    /// then this will panic.
+    ///
+    /// ```rust
+    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// #
+    /// use ::axum::Json;
+    /// use ::axum::routing::Router;
+    /// use ::axum::routing::put;
+    /// use ::serde_json::json;
+    ///
+    /// use ::axum_test::TestServer;
+    ///
+    /// let app = Router::new()
+    ///     .route(&"/todo", put(|| async { unimplemented!() }))
+    ///     .into_make_service();
+    ///
+    /// let server = TestServer::new(app)?;
+    ///
+    /// // If this doesn't return a value in the 2xx range,
+    /// // then it will panic.
+    /// server.put(&"/todo")
+    ///     .expect_success()
+    ///     .json(json!({
+    ///         "task": "buy milk",
+    ///     }))
+    ///     .await;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    pub fn expect_success(mut self) -> Self {
+        self.is_expecting_success = Some(true);
         self
     }
 
-    /// Marks that this request should expect to succeed.
-    /// Success is deemend as returning a 2xx status code.
+    /// Marks that this request is expected to return a HTTP status code
+    /// outside of the 2xx range.
     ///
-    /// Note this is the default behaviour when creating a new `TestRequest`.
-    pub fn expect_success(mut self) -> Self {
-        self.is_expecting_success = Some(true);
+    /// If a code _within_ the 2xx range is returned,
+    /// then this will panic.
+    pub fn expect_failure(mut self) -> Self {
+        self.is_expecting_success = Some(false);
         self
     }
 

--- a/src/test_request/test_request_config.rs
+++ b/src/test_request/test_request_config.rs
@@ -3,6 +3,7 @@ use ::http::Method;
 #[derive(Debug, Clone)]
 pub struct TestRequestConfig {
     pub is_saving_cookies: bool,
+    pub is_expecting_success_by_default: bool,
     pub content_type: Option<String>,
     pub method: Method,
     pub full_request_path: String,

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -49,7 +49,7 @@ lazy_static! {
 /// use ::axum_test::TestServer;
 ///
 /// let app = Router::new()
-///     .route(&"/test", get(|| async { "hello!" }))
+///     .route(&"/todo", get(|| async { "hello!" }))
 ///     .into_make_service();
 ///
 /// let server = TestServer::new(app)?;

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -71,6 +71,7 @@ pub struct TestServer {
     server_thread: JoinHandle<()>,
     server_address: String,
     save_cookies: bool,
+    expect_success_by_default: bool,
     default_content_type: Option<String>,
     is_requests_http_restricted: bool,
 }
@@ -116,6 +117,7 @@ impl TestServer {
             server_thread,
             server_address: socket_address.to_string(),
             save_cookies: config.save_cookies,
+            expect_success_by_default: config.expect_success_by_default,
             default_content_type: config.default_content_type,
             is_requests_http_restricted: config.restrict_requests_with_http_schema,
         };
@@ -232,6 +234,7 @@ impl TestServer {
 
         TestRequestConfig {
             is_saving_cookies: self.save_cookies,
+            is_expecting_success_by_default: self.expect_success_by_default,
             content_type: self.default_content_type.clone(),
             full_request_path,
             method,
@@ -617,5 +620,64 @@ mod test_clear_query_params {
             .get(&"/query")
             .await
             .assert_text(&"has first? true, has second? true");
+    }
+}
+
+#[cfg(test)]
+mod test_expect_success_by_default {
+    use super::*;
+
+    use ::axum::routing::get;
+    use ::axum::Router;
+
+    #[tokio::test]
+    async fn it_should_not_panic_by_default_if_accessing_404_route() {
+        let app = Router::new().into_make_service();
+        let server = TestServer::new(app).expect("Should create test server");
+
+        server.get(&"/some_unknown_route").await;
+    }
+
+    #[tokio::test]
+    async fn it_should_not_panic_by_default_if_accessing_200_route() {
+        let app = Router::new()
+            .route("/known_route", get(|| async { "🦊🦊🦊" }))
+            .into_make_service();
+        let server = TestServer::new(app).expect("Should create test server");
+
+        server.get(&"/known_route").await;
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn it_should_panic_by_default_if_accessing_404_route_and_expect_success_on() {
+        let app = Router::new().into_make_service();
+        let server = TestServer::new_with_config(
+            app,
+            TestServerConfig {
+                expect_success_by_default: true,
+                ..TestServerConfig::default()
+            },
+        )
+        .expect("Should create test server");
+
+        server.get(&"/some_unknown_route").await;
+    }
+
+    #[tokio::test]
+    async fn it_should_not_panic_by_default_if_accessing_200_route_and_expect_success_on() {
+        let app = Router::new()
+            .route("/known_route", get(|| async { "🦊🦊🦊" }))
+            .into_make_service();
+        let server = TestServer::new_with_config(
+            app,
+            TestServerConfig {
+                expect_success_by_default: true,
+                ..TestServerConfig::default()
+            },
+        )
+        .expect("Should create test server");
+
+        server.get(&"/known_route").await;
     }
 }

--- a/src/test_server_config.rs
+++ b/src/test_server_config.rs
@@ -57,6 +57,15 @@ pub struct TestServerConfig {
     /// **Defaults** to false (being turned off).
     pub save_cookies: bool,
 
+    /// Sets requests made by the server to always expect a status code returned in the 2xx range,
+    /// and to panic if that is missing.
+    ///
+    /// This is useful when making multiple requests at a start of test
+    /// which you presume should always work. It also helps to make tests more explicit.
+    ///
+    /// **Defaults** to false (being turned off).
+    pub expect_success_by_default: bool,
+
     /// If you make a request with a 'http://' schema,
     /// then it will ignore the Test Server's address.
     ///
@@ -85,6 +94,7 @@ impl Default for TestServerConfig {
             ip: None,
             port: None,
             save_cookies: false,
+            expect_success_by_default: false,
             restrict_requests_with_http_schema: false,
             default_content_type: None,
         }


### PR DESCRIPTION
# Changes

 * The `TestRequest` failure expectation behaviour is now disabled by default.
 * Expect success behaviour can now be turned through the `TestServerConfig`
