### PR TITLE
feat: server expect success and failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "12.0.0"
+version = "12.1.0"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"

--- a/src/internals/expected_state.rs
+++ b/src/internals/expected_state.rs
@@ -1,0 +1,16 @@
+#[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
+pub enum ExpectedState {
+    Success,
+    Failure,
+    None,
+}
+
+impl From<Option<bool>> for ExpectedState {
+    fn from(maybe_success: Option<bool>) -> Self {
+        match maybe_success {
+            None => Self::None,
+            Some(true) => Self::Success,
+            Some(false) => Self::Failure,
+        }
+    }
+}

--- a/src/internals/mod.rs
+++ b/src/internals/mod.rs
@@ -1,2 +1,5 @@
+mod expected_state;
+pub use self::expected_state::*;
+
 mod query_params_store;
 pub use self::query_params_store::*;

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -825,6 +825,25 @@ mod test_expect_success {
         // Get the request.
         server.get(&"/some_unknown_route").expect_success().await;
     }
+
+    #[tokio::test]
+    async fn it_should_override_what_test_server_has_set() {
+        async fn get_ping() -> &'static str {
+            "pong!"
+        }
+
+        // Build an application with a route.
+        let app = Router::new()
+            .route("/ping", get(get_ping))
+            .into_make_service();
+
+        // Run the server.
+        let mut server = TestServer::new(app).expect("Should create test server");
+        server.expect_failure();
+
+        // Get the request.
+        server.get(&"/ping").expect_success().await;
+    }
 }
 
 #[cfg(test)]
@@ -882,6 +901,19 @@ mod test_expect_failure {
 
         // Get the request.
         server.get(&"/accepted").expect_failure().await;
+    }
+
+    #[tokio::test]
+    async fn it_should_should_override_what_test_server_has_set() {
+        // Build an application with a route.
+        let app = Router::new().into_make_service();
+
+        // Run the server.
+        let mut server = TestServer::new(app).expect("Should create test server");
+        server.expect_success();
+
+        // Get the request.
+        server.get(&"/some_unknown_route").expect_failure().await;
     }
 }
 

--- a/src/test_request/test_request_config.rs
+++ b/src/test_request/test_request_config.rs
@@ -1,10 +1,12 @@
 use ::http::Method;
 use ::url::Url;
 
+use crate::internals::ExpectedState;
+
 #[derive(Debug, Clone)]
 pub struct TestRequestConfig {
     pub is_saving_cookies: bool,
-    pub is_expecting_success_by_default: bool,
+    pub expected_state: ExpectedState,
     pub content_type: Option<String>,
     pub method: Method,
     pub full_request_url: Url,

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -1055,3 +1055,124 @@ mod test_content_type {
         assert_eq!(text, "text/plain");
     }
 }
+
+#[cfg(test)]
+mod test_expect_success {
+    use crate::TestServer;
+    use ::axum::routing::get;
+    use ::axum::Router;
+    use ::http::StatusCode;
+
+    #[tokio::test]
+    async fn it_should_not_panic_if_success_is_returned() {
+        async fn get_ping() -> &'static str {
+            "pong!"
+        }
+
+        // Build an application with a route.
+        let app = Router::new()
+            .route("/ping", get(get_ping))
+            .into_make_service();
+
+        // Run the server.
+        let mut server = TestServer::new(app).expect("Should create test server");
+        server.expect_success();
+
+        // Get the request.
+        server.get(&"/ping").await;
+    }
+
+    #[tokio::test]
+    async fn it_should_not_panic_on_other_2xx_status_code() {
+        async fn get_accepted() -> StatusCode {
+            StatusCode::ACCEPTED
+        }
+
+        // Build an application with a route.
+        let app = Router::new()
+            .route("/accepted", get(get_accepted))
+            .into_make_service();
+
+        // Run the server.
+        let mut server = TestServer::new(app).expect("Should create test server");
+        server.expect_success();
+
+        // Get the request.
+        server.get(&"/accepted").await;
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn it_should_panic_on_404() {
+        // Build an application with a route.
+        let app = Router::new().into_make_service();
+
+        // Run the server.
+        let mut server = TestServer::new(app).expect("Should create test server");
+        server.expect_success();
+
+        // Get the request.
+        server.get(&"/some_unknown_route").await;
+    }
+}
+
+#[cfg(test)]
+mod test_expect_failure {
+    use crate::TestServer;
+    use ::axum::routing::get;
+    use ::axum::Router;
+    use ::http::StatusCode;
+
+    #[tokio::test]
+    async fn it_should_not_panic_if_expect_failure_on_404() {
+        // Build an application with a route.
+        let app = Router::new().into_make_service();
+
+        // Run the server.
+        let mut server = TestServer::new(app).expect("Should create test server");
+        server.expect_failure();
+
+        // Get the request.
+        server.get(&"/some_unknown_route").await;
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn it_should_panic_if_success_is_returned() {
+        async fn get_ping() -> &'static str {
+            "pong!"
+        }
+
+        // Build an application with a route.
+        let app = Router::new()
+            .route("/ping", get(get_ping))
+            .into_make_service();
+
+        // Run the server.
+        let mut server = TestServer::new(app).expect("Should create test server");
+        server.expect_failure();
+
+        // Get the request.
+        server.get(&"/ping").await;
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn it_should_panic_on_other_2xx_status_code() {
+        async fn get_accepted() -> StatusCode {
+            StatusCode::ACCEPTED
+        }
+
+        // Build an application with a route.
+        let app = Router::new()
+            .route("/accepted", get(get_accepted))
+            .into_make_service();
+
+        // Run the server.
+        let mut server = TestServer::new(app).expect("Should create test server");
+        server.expect_failure();
+
+        // Get the request.
+        server.get(&"/accepted").await;
+    }
+}


### PR DESCRIPTION
# Changes

 * add `TestServer::expect_success()`
 * add `TestServer::expect_failure()`

# Comments

This adds two functions to the `TestServer` which are present in the config, and the `TestRequest`. It is to make the API more uniform.
