### PR TITLE
Fix example assertion in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ and then assert the responses returned:
           .get("/ping")
           .await;
 
-      assert_eq!(response.contents, "pong!");
+      assert_eq!(response.as_bytes(), "pong!");
   }
 ```
 


### PR DESCRIPTION
Trying out this crate and tried to run the example code in the Readme. Noticed this error.

```
error[E0609]: no field `contents` on type `TestResponse`
```