### PR TITLE
Feat request format tidyup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "13.3.1"
+version = "13.3.2"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"

--- a/src/internals/mod.rs
+++ b/src/internals/mod.rs
@@ -7,6 +7,9 @@ pub use self::expected_state::*;
 mod status_code_formatter;
 pub use self::status_code_formatter::*;
 
+mod request_path_formatter;
+pub use self::request_path_formatter::*;
+
 mod query_params_store;
 pub use self::query_params_store::*;
 

--- a/src/internals/request_path_formatter.rs
+++ b/src/internals/request_path_formatter.rs
@@ -1,4 +1,4 @@
-use ::http::StatusCode;
+use ::http::Method;
 use ::std::fmt;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -24,8 +24,8 @@ impl RequestPathFormatter {
 
 impl fmt::Display for RequestPathFormatter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let method = self.method;
-        let user_requested_path = self.user_requested_path;
+        let method = &self.method;
+        let user_requested_path = &self.user_requested_path;
 
         write!(f, "{method} {user_requested_path}")
     }
@@ -37,7 +37,7 @@ mod test_fmt {
 
     #[test]
     fn it_should_format_with_path_given() {
-        let debug = RequestPathFormatter(Method::GET, "/donkeys");
+        let debug = RequestPathFormatter::new(Method::GET, "/donkeys".to_string());
         let output = format!("{}", debug);
 
         assert_eq!(output, "GET /donkeys");

--- a/src/internals/request_path_formatter.rs
+++ b/src/internals/request_path_formatter.rs
@@ -1,0 +1,45 @@
+use ::http::StatusCode;
+use ::std::fmt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RequestPathFormatter {
+    method: Method,
+
+    /// This is the path that the user requested.
+    user_requested_path: String,
+}
+
+impl RequestPathFormatter {
+    pub fn new(method: Method, user_requested_path: String) -> Self {
+        Self {
+            method,
+            user_requested_path,
+        }
+    }
+
+    pub fn method(&self) -> &Method {
+        &self.method
+    }
+}
+
+impl fmt::Display for RequestPathFormatter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let method = self.method;
+        let user_requested_path = self.user_requested_path;
+
+        write!(f, "{method} {user_requested_path}")
+    }
+}
+
+#[cfg(test)]
+mod test_fmt {
+    use super::*;
+
+    #[test]
+    fn it_should_format_with_path_given() {
+        let debug = RequestPathFormatter(Method::GET, "/donkeys");
+        let output = format!("{}", debug);
+
+        assert_eq!(output, "GET /donkeys");
+    }
+}

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -26,12 +26,13 @@ use ::url::Url;
 
 use crate::internals::ExpectedState;
 use crate::internals::QueryParamsStore;
+use crate::internals::RequestPathFormatter;
 use crate::transport_layer::TransportLayer;
 use crate::ServerSharedState;
 use crate::TestResponse;
 
-mod test_request_config;
 pub(crate) use self::test_request_config::*;
+mod test_request_config;
 
 const JSON_CONTENT_TYPE: &'static str = &"application/json";
 const FORM_CONTENT_TYPE: &'static str = &"application/x-www-form-urlencoded";
@@ -115,10 +116,9 @@ impl TestRequest {
     ) -> Result<Self> {
         let expected_state = config.expected_state;
         let server_locked = server_state.as_ref().lock().map_err(|err| {
+            let request_format = config.request_format;
             anyhow!(
-                "Failed to lock InternalTestServer for {} {}, received {err:?}",
-                config.method,
-                config.path,
+                "Failed to lock InternalTestServer, for request {request_format}, received {err:?}",
             )
         })?;
 
@@ -318,9 +318,11 @@ impl TestRequest {
     where
         V: Serialize,
     {
-        self.query_params
-            .add(query_params)
-            .expect("It should serialize query parameters");
+        self.query_params.add(query_params).with_context(|| {
+            let request_format = config.request_format;
+            format!("It should serialize query parameters, for request {request_format}")
+        });
+
         self
     }
 
@@ -397,13 +399,12 @@ impl TestRequest {
         let save_cookies = self.config.is_saving_cookies;
         let path = self.config.path;
         let body = self.body.unwrap_or(Body::empty());
-        let method = self.config.method;
+        let request_format = self.config.request_format;
 
         let url = Self::build_url_query_params(self.config.full_request_url, &self.query_params);
         let request = Self::build_request(
-            method.clone(),
+            &request_format,
             &url,
-            path.clone(),
             body,
             self.config.content_type,
             self.cookies,
@@ -412,7 +413,9 @@ impl TestRequest {
 
         let (parts, response_bytes) = {
             let mut transport_locked = self.transport.as_ref().lock().map_err(|err| {
-                anyhow!("Expect Response to succeed on request {method} {path}, received {err:?}")
+                anyhow!(
+                    "Expect Response to succeed, for request {request_format}, received {err:?}"
+                )
             })?;
             transport_locked.send(request).await?
         };
@@ -422,7 +425,7 @@ impl TestRequest {
             ServerSharedState::add_cookies_by_header(&mut self.server_state, cookie_headers)?;
         }
 
-        let response = TestResponse::new(method, path, url, parts, response_bytes);
+        let response = TestResponse::new(request_format, url, parts, response_bytes);
 
         // Assert if ok or not.
         match expected_state {
@@ -444,19 +447,21 @@ impl TestRequest {
     }
 
     fn build_request(
-        method: Method,
+        request_format: &RequestPathFormatter,
         url: &Url,
-        path: String,
         body: Body,
         content_type: Option<String>,
         cookies: CookieJar,
         headers: Vec<(HeaderName, HeaderValue)>,
     ) -> Result<Request<Body>> {
-        let mut request_builder = Request::builder().uri(url.as_str()).method(method);
+        let mut request_builder = Request::builder()
+            .uri(url.as_str())
+            .method(request_format.method().clone());
 
         // Add all the headers we have.
         if let Some(content_type) = content_type {
-            let (header_key, header_value) = build_content_type_header(content_type)?;
+            let (header_key, header_value) =
+                build_content_type_header(&content_type, &request_format)?;
             request_builder = request_builder.header(header_key, header_value);
         }
 
@@ -473,10 +478,7 @@ impl TestRequest {
         }
 
         let request = request_builder.body(body).with_context(|| {
-            format!(
-                "Expect valid hyper Request to be built on request to {}",
-                path
-            )
+            format!("Expect valid hyper Request to be built, for request {request_format}")
         })?;
 
         Ok(request)
@@ -494,9 +496,8 @@ impl TryFrom<TestRequest> for Request<Body> {
         let body = test_request.body.unwrap_or(Body::empty());
 
         TestRequest::build_request(
-            test_request.config.method,
+            &test_request.config.request_format,
             &url,
-            test_request.config.path,
             body,
             test_request.config.content_type,
             test_request.cookies,
@@ -510,13 +511,24 @@ impl IntoFuture for TestRequest {
     type IntoFuture = AutoFuture<TestResponse>;
 
     fn into_future(self) -> Self::IntoFuture {
-        AutoFuture::new(async { self.send().await.expect("Sending request failed") })
+        AutoFuture::new(async {
+            self.send()
+                .await
+                .with_context(|| format!("Sending request failed"))
+                .unwrap()
+        })
     }
 }
 
-fn build_content_type_header(content_type: String) -> Result<(HeaderName, HeaderValue)> {
-    let header_value = HeaderValue::from_str(&content_type)
-        .with_context(|| format!("Failed to store header content type '{}'", content_type))?;
+fn build_content_type_header(
+    content_type: &str,
+    request_format: &RequestPathFormatter,
+) -> Result<(HeaderName, HeaderValue)> {
+    let header_value = HeaderValue::from_str(content_type).with_context(|| {
+        format!(
+            "Failed to store header content type '{content_type}', for request {request_format}"
+        )
+    })?;
 
     Ok((header::CONTENT_TYPE, header_value))
 }

--- a/src/test_request/test_request_config.rs
+++ b/src/test_request/test_request_config.rs
@@ -1,4 +1,3 @@
-use ::http::Method;
 use ::url::Url;
 
 use crate::internals::ExpectedState;

--- a/src/test_request/test_request_config.rs
+++ b/src/test_request/test_request_config.rs
@@ -2,13 +2,13 @@ use ::http::Method;
 use ::url::Url;
 
 use crate::internals::ExpectedState;
+use crate::internals::RequestPathFormatter;
 
 #[derive(Debug, Clone)]
 pub struct TestRequestConfig {
     pub is_saving_cookies: bool,
     pub expected_state: ExpectedState,
     pub content_type: Option<String>,
-    pub method: Method,
     pub full_request_url: Url,
-    pub path: String,
+    pub request_format: RequestPathFormatter,
 }

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -8,7 +8,6 @@ use ::http::header::SET_COOKIE;
 use ::http::response::Parts;
 use ::http::HeaderMap;
 use ::http::HeaderValue;
-use ::http::Method;
 use ::http::StatusCode;
 use ::serde::de::DeserializeOwned;
 use ::std::convert::AsRef;

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -21,6 +21,7 @@ use crate::Transport;
 
 mod server_shared_state;
 pub(crate) use self::server_shared_state::*;
+use crate::internals::RequestPathFormatter;
 
 const DEFAULT_URL_ADDRESS: &'static str = "http://localhost";
 
@@ -163,16 +164,12 @@ impl TestServer {
 
     /// Creates a HTTP request, to the method and path provided.
     pub fn method(&self, method: Method, path: &str) -> TestRequest {
-        let debug_method = method.clone();
-        let config = self.test_request_config(method, path);
+        let config = self.test_request_config(method.clone(), path);
         let maybe_request = TestRequest::new(self.state.clone(), self.transport.clone(), config);
 
         maybe_request
             .with_context(|| {
-                format!(
-                    "Trying to create internal request for {} {}",
-                    debug_method, path
-                )
+                format!("Trying to create internal request, for request {method} {path}")
             })
             .unwrap()
     }
@@ -303,8 +300,7 @@ impl TestServer {
             expected_state: self.expected_state,
             content_type: self.default_content_type.clone(),
             full_request_url: build_url(url, path, self.is_http_path_restricted),
-            method,
-            path: path.to_string(),
+            request_format: RequestPathFormatter::new(method, path.to_string()),
         }
     }
 }

--- a/src/test_server_config.rs
+++ b/src/test_server_config.rs
@@ -55,11 +55,15 @@ pub struct TestServerConfig {
     /// **Defaults** to false (being turned off).
     pub save_cookies: bool,
 
-    /// Sets requests made by the server to always expect a status code returned in the 2xx range,
-    /// and to panic if that is missing.
+    /// Asserts that requests made to the test server,
+    /// will by default,
+    /// return a status code in the 2xx range.
+    ///
+    /// This can be overridden on a per request basis using
+    /// [`TestRequest::expect_failure()`](crate::TestRequest::expect_failure()).
     ///
     /// This is useful when making multiple requests at a start of test
-    /// which you presume should always work. It also helps to make tests more explicit.
+    /// which you presume should always work.
     ///
     /// **Defaults** to false (being turned off).
     pub expect_success_by_default: bool,


### PR DESCRIPTION
# Changes

 * Move Method + path information into common `RequestPathFormatter` .
 * Update `TestRequest` errors to include the requested path.

# Comments

This is a continuing refactor to make all of the error messages similar and use the same common information across the board.
