### PR TITLE
fix: upstream port reserving bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "13.4.0"
+version = "13.4.1"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"
@@ -25,7 +25,7 @@ cookie = "0.18.0"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1"] }
 pretty_assertions = { version = "1.4.0", optional = true}
-reserve-port = "1.3.0"
+reserve-port = "2.0.0"
 serde = { version = "1.0" }
 serde_json = "1.0"
 serde_urlencoded = "0.7.1"

--- a/src/internals/starting_tcp_setup.rs
+++ b/src/internals/starting_tcp_setup.rs
@@ -6,7 +6,7 @@ use ::std::net::Ipv4Addr;
 use ::std::net::SocketAddr;
 use ::std::net::TcpListener;
 
-pub const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+pub const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
 pub struct StartingTcpSetup {
     pub maybe_reserved_port: Option<ReservedPort>,

--- a/src/transport_layer/into_transport_layer/into_make_service.rs
+++ b/src/transport_layer/into_transport_layer/into_make_service.rs
@@ -19,8 +19,10 @@ impl IntoTransportLayer for IntoMakeService<Router> {
     ) -> Result<Box<dyn TransportLayer>> {
         let (socket_addr, tcp_listener, maybe_reserved_port) =
             builder.tcp_listener_with_reserved_port()?;
+
+        let maybe_local_address = tcp_listener.local_addr().ok();
         let server_builder = AxumServer::from_tcp(tcp_listener)
-            .with_context(|| "Failed to create ::axum::Server for TestServer")?;
+            .with_context(|| format!("Failed to create ::axum::Server for TestServer, with address '{maybe_local_address:?}'"))?;
 
         let server = server_builder.serve(self);
         let server_handle = spawn(async move {

--- a/src/util/new_random_socket_addr.rs
+++ b/src/util/new_random_socket_addr.rs
@@ -5,7 +5,7 @@ use ::std::net::SocketAddr;
 
 use crate::util::new_random_port;
 
-pub(crate) const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+pub(crate) const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
 /// Generates a `SocketAddr` on the IP 127.0.0.1, using a random port.
 pub fn new_random_socket_addr() -> Result<SocketAddr> {

--- a/src/util/new_random_tcp_listener.rs
+++ b/src/util/new_random_tcp_listener.rs
@@ -5,7 +5,7 @@ use ::std::net::Ipv4Addr;
 use ::std::net::TcpListener;
 use std::net::SocketAddr;
 
-pub(crate) const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+pub(crate) const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
 /// Binds a `TcpListener` on the IP 127.0.0.1, using a random port.
 ///


### PR DESCRIPTION
# Changes

 * Upgrade the port reserve crate to the latest version, to fix IP reservation bug.

# Comments

The reserve-port crate is using an unspecified IP, and Axum Test is using Localhost. This can cause a port to be offered which isn't available.
