### PR TITLE
docs: add more documentation on multipart form and parts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "14.2.1"
+version = "14.2.2"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"

--- a/src/multipart/mod.rs
+++ b/src/multipart/mod.rs
@@ -1,3 +1,61 @@
+//! 
+//! This supplies the building blocks for sending multipart forms using
+//! [`TestRequest::multipart()`](crate::TestRequest::multipart()).
+//! 
+//! The request body can be built using [`MultipartForm`](crate::multipart::MultipartForm) and [`Part`](crate::multipart::Part).
+//! 
+//! # Simple example
+//!
+//! ```rust
+//! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+//! #
+//! use ::axum::Router;
+//! use ::axum_test::TestServer;
+//! use ::axum_test::multipart::MultipartForm;
+//!
+//! let app = Router::new();
+//! let server = TestServer::new(app)?;
+//!
+//! let multipart_form = MultipartForm::new()
+//!     .add_text("name", "Joe")
+//!     .add_text("animals", "foxes");
+//! 
+//! let response = server.post(&"/my-form")
+//!     .multipart(multipart_form)
+//!     .await;
+//! #
+//! # Ok(()) }
+//! ```
+//!
+//! # Sending byte parts
+//!
+//! ```rust
+//! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+//! #
+//! use ::axum::Router;
+//! use ::axum_test::TestServer;
+//! use ::axum_test::multipart::MultipartForm;
+//! use ::axum_test::multipart::Part;
+//!
+//! let app = Router::new();
+//! let server = TestServer::new(app)?;
+//!
+//! let image_bytes = include_bytes!("../../README.md");
+//! let image_part = Part::bytes(image_bytes.as_slice())
+//!     .file_name(&"README.md")
+//!     .mime_type(&"text/markdown");
+//! 
+//! let multipart_form = MultipartForm::new()
+//!     .add_part("file", image_part);
+//! 
+//! let response = server.post(&"/my-form")
+//!     .multipart(multipart_form)
+//!     .await;
+//! #
+//! # Ok(()) }
+//! ```
+//!
+
 mod multipart_form;
 pub use self::multipart_form::*;
 

--- a/src/multipart/multipart_form.rs
+++ b/src/multipart/multipart_form.rs
@@ -17,7 +17,7 @@ impl MultipartForm {
         }
     }
 
-    /// Adds a new key / value pair to be sent.
+    /// Creates a text part, and adds it to be sent.
     pub fn add_text<N, T>(mut self, name: N, text: T) -> Self
     where
         N: Display,
@@ -27,18 +27,21 @@ impl MultipartForm {
         self
     }
 
-    /// Adds a new key / value pair to be sent.
+    /// Adds a new section to this multipart form to be sent.
+    /// 
+    /// See [`Part`](crate::multipart::Part).
     pub fn add_part<N>(mut self, name: N, part: Part) -> Self
     where
         N: Display,
     {
         let reader = Cursor::new(part.bytes);
         self.inner
-            .add_reader_2(name, reader, part.file_name, part.mime_type);
+            .add_reader_2(name, reader, part.file_name, Some(part.mime_type));
 
         self
     }
 
+    /// Returns the content type this form will use when it is sent.
     pub fn content_type(&self) -> String {
         self.inner.content_type()
     }

--- a/src/multipart/part.rs
+++ b/src/multipart/part.rs
@@ -3,13 +3,22 @@ use ::bytes::Bytes;
 use ::mime::Mime;
 use ::std::fmt::Display;
 
+/// 
+/// For creating a section of a MultipartForm.
+/// 
+/// Use [`Part::text()`](crate::multipart::Part::text()) and [`Part::bytes()`](crate::multipart::Part::bytes()) for creating new instances.
+/// Then attach them to a `MultipartForm` using [`MultipartForm::add_part()`](crate::multipart::MultipartForm::add_part()).
+/// 
 pub struct Part {
     pub(crate) bytes: Bytes,
     pub(crate) file_name: Option<String>,
-    pub(crate) mime_type: Option<Mime>,
+    pub(crate) mime_type: Mime,
 }
 
 impl Part {
+    /// Creates a new part of a multipart form, that will send text.
+    /// 
+    /// The default mime type for this part will be `text/plain`,
     pub fn text<T>(text: T) -> Self
     where
         T: Display,
@@ -17,10 +26,13 @@ impl Part {
         Self {
             bytes: text.to_string().into_bytes().into(),
             file_name: None,
-            mime_type: Some(mime::TEXT_PLAIN),
+            mime_type: mime::TEXT_PLAIN,
         }
     }
 
+    /// Creates a new part of a multipart form, that will upload bytes.
+    /// 
+    /// The default mime type for this part will be `application/octet-stream`,
     pub fn bytes<B>(bytes: B) -> Self
     where
         B: Into<Bytes>,
@@ -28,11 +40,13 @@ impl Part {
         Self {
             bytes: bytes.into(),
             file_name: None,
-            mime_type: None,
+            mime_type: mime::APPLICATION_OCTET_STREAM,
         }
     }
 
-    /// Sets the mime type for this multiform part.
+    /// Sets the file name for this part of a multipart form.
+    /// 
+    /// By default there is no filename. This will set one.
     pub fn file_name<T>(mut self, file_name: T) -> Self
     where
         T: Display,
@@ -41,7 +55,11 @@ impl Part {
         self
     }
 
-    /// Sets the mime type for this multiform part.
+    /// Sets the mime type for this part of a multipart form.
+    /// 
+    /// The default mime type is `text/plain` or `application/octet-stream`,
+    /// depending on how this instance was created.
+    /// This function will replace that.
     pub fn mime_type<M>(mut self, mime_type: M) -> Self
     where
         M: AsRef<str>,
@@ -52,7 +70,7 @@ impl Part {
             .with_context(|| format!("Failed to parse '{raw_mime_type}' as a Mime type"))
             .unwrap();
 
-        self.mime_type = Some(parsed_mime_type);
+        self.mime_type = parsed_mime_type;
         self
     }
 }


### PR DESCRIPTION
# Changes

 * Add documentation for `multipart::MultipartForm` and `multipart::Part`.
