### PR TITLE
fix: cookie value not stripped

### DIFF
--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -530,7 +530,7 @@ impl TestRequest {
 
         // Add all the cookies as headers
         for cookie in cookies.iter() {
-            let cookie_raw = cookie.to_string();
+            let cookie_raw = cookie.stripped().to_string();
             let header_value = HeaderValue::from_str(&cookie_raw)?;
             request_builder = request_builder.header(header::COOKIE, header_value);
         }


### PR DESCRIPTION
Strip cookie value so cookie header will only contains `{name}={value}` while building request
See https://docs.rs/cookie/latest/cookie/struct.Cookie.html#method.stripped