### PR TITLE
feat: add Yaml support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "14.2.2"
+version = "14.3.0"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"
@@ -14,6 +14,7 @@ readme = "README.md"
 [features]
 default = ["pretty-assertions"]
 pretty-assertions = ["dep:pretty_assertions"]
+yaml = ["dep:serde_yaml"]
 
 [dependencies]
 async-trait = "0.1.75"
@@ -28,10 +29,11 @@ hyper-util = { version = "0.1.1", features = ["client", "http1", "client-legacy"
 hyper = { version = "1.1", features = ["http1"] }
 mime = "0.3.17"
 rust-multipart-rfc7578_2 = "0.6"
-pretty_assertions = { version = "1.4.0", optional = true}
+pretty_assertions = { version = "1.4.0", optional = true }
 reserve-port = "2.0"
 serde = { version = "1.0" }
 serde_json = "1.0"
+serde_yaml = { version = "0.8", optional = true }
 serde_urlencoded = "0.7.1"
 smallvec = "1.11.2"
 tokio = { version = "1.35", features = ["rt", "time"] }
@@ -41,6 +43,7 @@ url = "2.5.0"
 [dev-dependencies]
 axum = { version = "0.7", features = ["multipart", "tokio"] }
 axum-extra = { version = "0.9.0", features = ["cookie"] }
+axum-yaml = "0.4.0"
 local-ip-address = "0.5.4"
 regex = "1.10.2"
 serde-email = { version = "3.0", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -85,3 +85,4 @@ Querying your application on the `TestServer` supports all of the common request
 Here are a list of all features so far that can be enabled:
 
  * `pretty-assertions` **on by default**, uses the [pretty assertions crate](https://crates.io/crates/pretty_assertions) for the output to the `assert_*` functions.
+ * `yaml` _off by default_, adds support for sending, receiving, and asserting, yaml content.

--- a/src/multipart/mod.rs
+++ b/src/multipart/mod.rs
@@ -1,9 +1,9 @@
-//! 
+//!
 //! This supplies the building blocks for sending multipart forms using
 //! [`TestRequest::multipart()`](crate::TestRequest::multipart()).
-//! 
+//!
 //! The request body can be built using [`MultipartForm`](crate::multipart::MultipartForm) and [`Part`](crate::multipart::Part).
-//! 
+//!
 //! # Simple example
 //!
 //! ```rust
@@ -19,7 +19,7 @@
 //! let multipart_form = MultipartForm::new()
 //!     .add_text("name", "Joe")
 //!     .add_text("animals", "foxes");
-//! 
+//!
 //! let response = server.post(&"/my-form")
 //!     .multipart(multipart_form)
 //!     .await;
@@ -44,10 +44,10 @@
 //! let image_part = Part::bytes(image_bytes.as_slice())
 //!     .file_name(&"README.md")
 //!     .mime_type(&"text/markdown");
-//! 
+//!
 //! let multipart_form = MultipartForm::new()
 //!     .add_part("file", image_part);
-//! 
+//!
 //! let response = server.post(&"/my-form")
 //!     .multipart(multipart_form)
 //!     .await;

--- a/src/multipart/multipart_form.rs
+++ b/src/multipart/multipart_form.rs
@@ -28,7 +28,7 @@ impl MultipartForm {
     }
 
     /// Adds a new section to this multipart form to be sent.
-    /// 
+    ///
     /// See [`Part`](crate::multipart::Part).
     pub fn add_part<N>(mut self, name: N, part: Part) -> Self
     where

--- a/src/multipart/part.rs
+++ b/src/multipart/part.rs
@@ -3,12 +3,12 @@ use ::bytes::Bytes;
 use ::mime::Mime;
 use ::std::fmt::Display;
 
-/// 
+///
 /// For creating a section of a MultipartForm.
-/// 
+///
 /// Use [`Part::text()`](crate::multipart::Part::text()) and [`Part::bytes()`](crate::multipart::Part::bytes()) for creating new instances.
 /// Then attach them to a `MultipartForm` using [`MultipartForm::add_part()`](crate::multipart::MultipartForm::add_part()).
-/// 
+///
 pub struct Part {
     pub(crate) bytes: Bytes,
     pub(crate) file_name: Option<String>,
@@ -17,7 +17,7 @@ pub struct Part {
 
 impl Part {
     /// Creates a new part of a multipart form, that will send text.
-    /// 
+    ///
     /// The default mime type for this part will be `text/plain`,
     pub fn text<T>(text: T) -> Self
     where
@@ -31,7 +31,7 @@ impl Part {
     }
 
     /// Creates a new part of a multipart form, that will upload bytes.
-    /// 
+    ///
     /// The default mime type for this part will be `application/octet-stream`,
     pub fn bytes<B>(bytes: B) -> Self
     where
@@ -45,7 +45,7 @@ impl Part {
     }
 
     /// Sets the file name for this part of a multipart form.
-    /// 
+    ///
     /// By default there is no filename. This will set one.
     pub fn file_name<T>(mut self, file_name: T) -> Self
     where
@@ -56,7 +56,7 @@ impl Part {
     }
 
     /// Sets the mime type for this part of a multipart form.
-    /// 
+    ///
     /// The default mime type is `text/plain` or `application/octet-stream`,
     /// depending on how this instance was created.
     /// This function will replace that.

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+set -e
+
+cargo check
 cargo test --example=example-todo
+cargo test  --features yaml,pretty-assertions "$@"
 cargo test "$@"


### PR DESCRIPTION
# Changes

 * Add Yaml support for sending, receiving, and asserting.

# Comments

Yaml support is behind the `yaml` feature flag.


