### PR TITLE
feat: add MsgPack support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [features]
 default = ["pretty-assertions"]
+msgpack = ["dep:rmp-serde"]
 pretty-assertions = ["dep:pretty_assertions"]
 yaml = ["dep:serde_yaml"]
 
@@ -31,6 +32,7 @@ mime = "0.3.17"
 rust-multipart-rfc7578_2 = "0.6"
 pretty_assertions = { version = "1.4.0", optional = true }
 reserve-port = "2.0"
+rmp-serde = { version = "1.1.2", optional = true }
 serde = { version = "1.0" }
 serde_json = "1.0"
 serde_yaml = { version = "0.8", optional = true }
@@ -43,6 +45,7 @@ url = "2.5.0"
 [dev-dependencies]
 axum = { version = "0.7", features = ["multipart", "tokio"] }
 axum-extra = { version = "0.9.0", features = ["cookie"] }
+axum-msgpack = "0.4.0"
 axum-yaml = "0.4.0"
 local-ip-address = "0.5.4"
 regex = "1.10.2"

--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ Here are a list of all features so far that can be enabled:
 
  * `pretty-assertions` **on by default**, uses the [pretty assertions crate](https://crates.io/crates/pretty_assertions) for the output to the `assert_*` functions.
  * `yaml` _off by default_, adds support for sending, receiving, and asserting, yaml content.
+ * `msgpack` _off by default_, adds support for sending, receiving, and asserting, msgpack content.

--- a/test.sh
+++ b/test.sh
@@ -5,4 +5,5 @@ set -e
 cargo check
 cargo test --example=example-todo
 cargo test  --features yaml,pretty-assertions "$@"
+cargo test  --features msgpack "$@"
 cargo test "$@"


### PR DESCRIPTION
# Changes

 * Adds support for sending, receiving and asserting [MsgPack](https://msgpack.org/) content

# Comments

Support is behind the `msgpack` flag. I didn't bump the crate version, but if it needed I am happy to do it.

