### PR TITLE
feat: add_raw_query_param

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "14.5.0"
+version = "14.6.0"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"
@@ -48,7 +48,7 @@ url = "2.5.0"
 
 [dev-dependencies]
 axum = { version = "0.7", features = ["multipart", "tokio"] }
-axum-extra = { version = "0.9.0", features = ["cookie"] }
+axum-extra = { version = "0.9.0", features = ["cookie", "query"] }
 axum-msgpack = "0.4.0"
 axum-yaml = "0.4.0"
 local-ip-address = "0.6.1"

--- a/src/internals/query_params_store.rs
+++ b/src/internals/query_params_store.rs
@@ -1,6 +1,5 @@
 use ::anyhow::Result;
 use ::serde::Serialize;
-use ::serde_urlencoded::to_string;
 use ::smallvec::SmallVec;
 use ::std::fmt::Display;
 use ::std::fmt::Formatter;
@@ -22,10 +21,14 @@ impl QueryParamsStore {
     where
         V: Serialize,
     {
-        let value_raw = to_string(query_params)?;
-        self.query_params.push(value_raw);
+        let value_raw = ::serde_urlencoded::to_string(query_params)?;
+        self.add_raw(value_raw);
 
         Ok(())
+    }
+
+    pub fn add_raw(&mut self, value_raw: String) {
+        self.query_params.push(value_raw);
     }
 
     pub fn clear(&mut self) {

--- a/src/test_server/server_shared_state.rs
+++ b/src/test_server/server_shared_state.rs
@@ -108,6 +108,12 @@ impl ServerSharedState {
         })?
     }
 
+    pub(crate) fn add_raw_query_param(this: &mut Arc<Mutex<Self>>, raw_value: &str) -> Result<()> {
+        with_this_mut(this, "add_raw_query_param", |this| {
+            this.query_params.add_raw(raw_value.to_string())
+        })
+    }
+
     pub(crate) fn clear_query_params(this: &mut Arc<Mutex<Self>>) -> Result<()> {
         with_this_mut(this, "clear_query_params", |this| this.query_params.clear())
     }


### PR DESCRIPTION
# Changes

Add escape hatches to add query params without url encoding:

 * Add `TestServer::add_raw_query_param`
 * Add `TestRequest::add_raw_query_param`
