### PR TITLE
feat: scheme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "14.6.0"
+version = "14.7.0"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -94,7 +94,11 @@ impl TestServer {
     where
         A: IntoTransportLayer,
     {
-        let shared_state = ServerSharedState::new();
+        let mut shared_state = ServerSharedState::new();
+        if let Some(scheme) = config.default_scheme {
+            shared_state.set_scheme_unlocked(scheme);
+        }
+        
         let shared_state_mutex = Mutex::new(shared_state);
         let state = Arc::new(shared_state_mutex);
 

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -98,7 +98,7 @@ impl TestServer {
         if let Some(scheme) = config.default_scheme {
             shared_state.set_scheme_unlocked(scheme);
         }
-        
+
         let shared_state_mutex = Mutex::new(shared_state);
         let state = Arc::new(shared_state_mutex);
 

--- a/src/test_server/server_shared_state.rs
+++ b/src/test_server/server_shared_state.rs
@@ -13,6 +13,7 @@ use crate::internals::QueryParamsStore;
 
 #[derive(Debug)]
 pub(crate) struct ServerSharedState {
+    scheme: Option<String>,
     cookies: CookieJar,
     query_params: QueryParamsStore,
     headers: Vec<(HeaderName, HeaderValue)>,
@@ -21,10 +22,15 @@ pub(crate) struct ServerSharedState {
 impl ServerSharedState {
     pub(crate) fn new() -> Self {
         Self {
+            scheme: None,
             cookies: CookieJar::new(),
             query_params: QueryParamsStore::new(),
             headers: Vec::new(),
         }
+    }
+
+    pub(crate) fn scheme<'a>(&'a self) -> Option<&'a str> {
+        self.scheme.as_deref()
     }
 
     pub(crate) fn cookies<'a>(&'a self) -> &'a CookieJar {
@@ -128,5 +134,9 @@ impl ServerSharedState {
         value: HeaderValue,
     ) -> Result<()> {
         with_this_mut(this, "add_header", |this| this.headers.push((name, value)))
+    }
+
+    pub(crate) fn set_scheme(this: &mut Arc<Mutex<Self>>, scheme: String) -> Result<()> {
+        with_this_mut(this, "set_scheme", |this| this.scheme = Some(scheme))
     }
 }

--- a/src/test_server/server_shared_state.rs
+++ b/src/test_server/server_shared_state.rs
@@ -139,4 +139,8 @@ impl ServerSharedState {
     pub(crate) fn set_scheme(this: &mut Arc<Mutex<Self>>, scheme: String) -> Result<()> {
         with_this_mut(this, "set_scheme", |this| this.scheme = Some(scheme))
     }
+
+    pub(crate) fn set_scheme_unlocked(&mut self, scheme: String) {
+        self.scheme = Some(scheme);
+    }
 }

--- a/src/test_server_config_builder.rs
+++ b/src/test_server_config_builder.rs
@@ -170,9 +170,7 @@ mod test_build {
 
     #[test]
     fn it_should_set_default_scheme_when_set() {
-        let config = TestServerConfig::builder()
-            .default_scheme("ftps")
-            .build();
+        let config = TestServerConfig::builder().default_scheme("ftps").build();
 
         assert_eq!(config.default_scheme, Some("ftps".to_string()));
     }

--- a/src/test_server_config_builder.rs
+++ b/src/test_server_config_builder.rs
@@ -75,6 +75,11 @@ impl TestServerConfigBuilder {
         self
     }
 
+    pub fn default_scheme(mut self, scheme: &str) -> Self {
+        self.config.default_scheme = Some(scheme.to_string());
+        self
+    }
+
     pub fn expect_success_by_default(mut self) -> Self {
         self.config.expect_success_by_default = true;
         self
@@ -161,6 +166,15 @@ mod test_build {
             .build();
 
         assert_eq!(config.default_content_type, Some("text/csv".to_string()));
+    }
+
+    #[test]
+    fn it_should_set_default_scheme_when_set() {
+        let config = TestServerConfig::builder()
+            .default_scheme("ftps")
+            .build();
+
+        assert_eq!(config.default_scheme, Some("ftps".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
# Changes

 * Add `TestServer::scheme()`
 * Add `TestRequest::scheme()`

One can now set the scheme (i.e. http or https) made on requests.
