### PR TITLE
docs: fix document of `TestServer::server_address()`

### DIFF
--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -182,7 +182,7 @@ impl TestServer {
     /// if an address is available.
     ///
     /// The address is available when running as a real web server,
-    /// by setting the [`TestServerConfig`](crate::TestServerConfig) `transport` field to `Transport::HttpRandomPort` or `Transport::HttpRandomPort`.
+    /// by setting the [`TestServerConfig`](crate::TestServerConfig) `transport` field to `Transport::HttpRandomPort` or `Transport::HttpIpPort`.
     ///
     /// This will return `None` when there is mock HTTP transport (the default).
     pub fn server_address(&self) -> Option<Url> {


### PR DESCRIPTION
# Changes

 * Fix doc comment of `TestServer::server_address()`

# Comments

`Transport::HttpRandomPort` ➡️ `Transport::HttpIpPort`

