### PR TITLE
fix: make `TransportLayer` sendable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "14.9.1"
+version = "14.10.0"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"

--- a/src/internals/with_this_mut.rs
+++ b/src/internals/with_this_mut.rs
@@ -3,7 +3,7 @@ use ::anyhow::Result;
 use ::std::sync::Arc;
 use ::std::sync::Mutex;
 
-pub fn with_this_mut<T, F, R>(this: &mut Arc<Mutex<T>>, name: &str, some_action: F) -> Result<R>
+pub fn with_this_mut<T, F, R>(this: &Arc<Mutex<T>>, name: &str, some_action: F) -> Result<R>
 where
     F: FnOnce(&mut T) -> R,
 {

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -194,7 +194,7 @@ impl TestServer {
     /// If a cookie with the same name already exists,
     /// then it will be replaced.
     pub fn add_cookie(&mut self, cookie: Cookie) {
-        ServerSharedState::add_cookie(&mut self.state, cookie)
+        ServerSharedState::add_cookie(&self.state, cookie)
             .with_context(|| format!("Trying to call add_cookie"))
             .unwrap()
     }
@@ -204,14 +204,14 @@ impl TestServer {
     /// Any cookies which have the same name as the new cookies,
     /// will get replaced.
     pub fn add_cookies(&mut self, cookies: CookieJar) {
-        ServerSharedState::add_cookies(&mut self.state, cookies)
+        ServerSharedState::add_cookies(&self.state, cookies)
             .with_context(|| format!("Trying to call add_cookies"))
             .unwrap()
     }
 
     /// Clears all of the cookies stored internally.
     pub fn clear_cookies(&mut self) {
-        ServerSharedState::clear_cookies(&mut self.state)
+        ServerSharedState::clear_cookies(&self.state)
             .with_context(|| format!("Trying to call clear_cookies"))
             .unwrap()
     }
@@ -249,7 +249,7 @@ impl TestServer {
     where
         V: Serialize,
     {
-        ServerSharedState::add_query_param(&mut self.state, key, value)
+        ServerSharedState::add_query_param(&self.state, key, value)
             .with_context(|| format!("Trying to call add_query_param"))
             .unwrap()
     }
@@ -259,7 +259,7 @@ impl TestServer {
     where
         V: Serialize,
     {
-        ServerSharedState::add_query_params(&mut self.state, query_params)
+        ServerSharedState::add_query_params(&self.state, query_params)
             .with_context(|| format!("Trying to call add_query_params"))
             .unwrap()
     }
@@ -267,28 +267,28 @@ impl TestServer {
     /// Adds a raw query param, with no urlencoding of any kind,
     /// to be send on *all* future requests.
     pub fn add_raw_query_param(&mut self, raw_query_param: &str) {
-        ServerSharedState::add_raw_query_param(&mut self.state, raw_query_param)
+        ServerSharedState::add_raw_query_param(&self.state, raw_query_param)
             .with_context(|| format!("Trying to call add_raw_query_param"))
             .unwrap()
     }
 
     /// Clears all query params set.
     pub fn clear_query_params(&mut self) {
-        ServerSharedState::clear_query_params(&mut self.state)
+        ServerSharedState::clear_query_params(&self.state)
             .with_context(|| format!("Trying to call clear_query_params"))
             .unwrap()
     }
 
     /// Adds a header to be sent with all future requests built from this `TestServer`.
     pub fn add_header<'c>(&mut self, name: HeaderName, value: HeaderValue) {
-        ServerSharedState::add_header(&mut self.state, name, value)
+        ServerSharedState::add_header(&self.state, name, value)
             .with_context(|| format!("Trying to call add_header"))
             .unwrap()
     }
 
     /// Clears all headers set so far.
     pub fn clear_headers(&mut self) {
-        ServerSharedState::clear_headers(&mut self.state)
+        ServerSharedState::clear_headers(&self.state)
             .with_context(|| format!("Trying to call clear_headers"))
             .unwrap()
     }
@@ -305,7 +305,7 @@ impl TestServer {
     /// use ::axum_test::TestServer;
     ///
     /// let app = Router::new();
-    /// let mut server = TestServer::new(app)?;
+    /// let server = TestServer::new(app)?;
     /// server
     ///     .scheme(&"https");
     ///
@@ -317,7 +317,7 @@ impl TestServer {
     /// ```
     ///
     pub fn scheme(&mut self, scheme: &str) {
-        ServerSharedState::set_scheme(&mut self.state, scheme.to_string())
+        ServerSharedState::set_scheme(&self.state, scheme.to_string())
             .with_context(|| format!("Trying to call set_scheme"))
             .unwrap()
     }

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -365,24 +365,6 @@ mod test_new {
     use ::std::net::SocketAddr;
 
     use crate::TestServer;
-    use tokio::sync::OnceCell;
-use super::*;
-    static SERVER_LOCAL: OnceCell<TestServer> = OnceCell::const_new(); // tokio OnceCell but its same for OnceLock
-    async fn get_server_local() -> &TestServer {
-        SERVER_LOCAL.get_or_init(|| async {
-            let config = TestServerConfig::builder()
-                .http_transport_with_ip_port(
-                    Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
-                    Some(PORT),
-                )
-                .build();
-    
-            let app = get_app().layer(MockConnectInfo(SocketAddr::from(([127, 0, 0, 1], PORT))));
-    
-            TestServer::new_with_config(app, config)
-                                .expect("Failed to create axum_test::TestServer")
-        }).await
-    }
 
     async fn get_ping() -> &'static str {
         "pong!"

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -305,7 +305,7 @@ impl TestServer {
     /// use ::axum_test::TestServer;
     ///
     /// let app = Router::new();
-    /// let server = TestServer::new(app)?;
+    /// let mut server = TestServer::new(app)?;
     /// server
     ///     .scheme(&"https");
     ///
@@ -365,6 +365,24 @@ mod test_new {
     use ::std::net::SocketAddr;
 
     use crate::TestServer;
+    use tokio::sync::OnceCell;
+use super::*;
+    static SERVER_LOCAL: OnceCell<TestServer> = OnceCell::const_new(); // tokio OnceCell but its same for OnceLock
+    async fn get_server_local() -> &TestServer {
+        SERVER_LOCAL.get_or_init(|| async {
+            let config = TestServerConfig::builder()
+                .http_transport_with_ip_port(
+                    Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
+                    Some(PORT),
+                )
+                .build();
+    
+            let app = get_app().layer(MockConnectInfo(SocketAddr::from(([127, 0, 0, 1], PORT))));
+    
+            TestServer::new_with_config(app, config)
+                                .expect("Failed to create axum_test::TestServer")
+        }).await
+    }
 
     async fn get_ping() -> &'static str {
         "pong!"

--- a/src/test_server/server_shared_state.rs
+++ b/src/test_server/server_shared_state.rs
@@ -49,7 +49,7 @@ impl ServerSharedState {
     ///
     /// They will be stored over the top of the existing cookies.
     pub(crate) fn add_cookies_by_header<'a, I>(
-        this: &mut Arc<Mutex<Self>>,
+        this: &Arc<Mutex<Self>>,
         cookie_headers: I,
     ) -> Result<()>
     where
@@ -73,7 +73,7 @@ impl ServerSharedState {
     /// Adds the given cookies.
     ///
     /// They will be stored over the top of the existing cookies.
-    pub(crate) fn clear_cookies(this: &mut Arc<Mutex<Self>>) -> Result<()> {
+    pub(crate) fn clear_cookies(this: &Arc<Mutex<Self>>) -> Result<()> {
         with_this_mut(this, "clear_cookies", |this| {
             this.cookies = CookieJar::new();
         })
@@ -82,7 +82,7 @@ impl ServerSharedState {
     /// Adds the given cookies.
     ///
     /// They will be stored over the top of the existing cookies.
-    pub(crate) fn add_cookies(this: &mut Arc<Mutex<Self>>, cookies: CookieJar) -> Result<()> {
+    pub(crate) fn add_cookies(this: &Arc<Mutex<Self>>, cookies: CookieJar) -> Result<()> {
         with_this_mut(this, "add_cookies", |this| {
             for cookie in cookies.iter() {
                 this.cookies.add(cookie.to_owned());
@@ -90,13 +90,13 @@ impl ServerSharedState {
         })
     }
 
-    pub(crate) fn add_cookie(this: &mut Arc<Mutex<Self>>, cookie: Cookie) -> Result<()> {
+    pub(crate) fn add_cookie(this: &Arc<Mutex<Self>>, cookie: Cookie) -> Result<()> {
         with_this_mut(this, "add_cookie", |this| {
             this.cookies.add(cookie.into_owned());
         })
     }
 
-    pub(crate) fn add_query_params<V>(this: &mut Arc<Mutex<Self>>, query_params: V) -> Result<()>
+    pub(crate) fn add_query_params<V>(this: &Arc<Mutex<Self>>, query_params: V) -> Result<()>
     where
         V: Serialize,
     {
@@ -105,7 +105,7 @@ impl ServerSharedState {
         })?
     }
 
-    pub(crate) fn add_query_param<V>(this: &mut Arc<Mutex<Self>>, key: &str, value: V) -> Result<()>
+    pub(crate) fn add_query_param<V>(this: &Arc<Mutex<Self>>, key: &str, value: V) -> Result<()>
     where
         V: Serialize,
     {
@@ -114,29 +114,29 @@ impl ServerSharedState {
         })?
     }
 
-    pub(crate) fn add_raw_query_param(this: &mut Arc<Mutex<Self>>, raw_value: &str) -> Result<()> {
+    pub(crate) fn add_raw_query_param(this: &Arc<Mutex<Self>>, raw_value: &str) -> Result<()> {
         with_this_mut(this, "add_raw_query_param", |this| {
             this.query_params.add_raw(raw_value.to_string())
         })
     }
 
-    pub(crate) fn clear_query_params(this: &mut Arc<Mutex<Self>>) -> Result<()> {
+    pub(crate) fn clear_query_params(this: &Arc<Mutex<Self>>) -> Result<()> {
         with_this_mut(this, "clear_query_params", |this| this.query_params.clear())
     }
 
-    pub(crate) fn clear_headers(this: &mut Arc<Mutex<Self>>) -> Result<()> {
+    pub(crate) fn clear_headers(this: &Arc<Mutex<Self>>) -> Result<()> {
         with_this_mut(this, "clear_headers", |this| this.headers.clear())
     }
 
     pub(crate) fn add_header<'c>(
-        this: &mut Arc<Mutex<Self>>,
+        this: &Arc<Mutex<Self>>,
         name: HeaderName,
         value: HeaderValue,
     ) -> Result<()> {
         with_this_mut(this, "add_header", |this| this.headers.push((name, value)))
     }
 
-    pub(crate) fn set_scheme(this: &mut Arc<Mutex<Self>>, scheme: String) -> Result<()> {
+    pub(crate) fn set_scheme(this: &Arc<Mutex<Self>>, scheme: String) -> Result<()> {
         with_this_mut(this, "set_scheme", |this| this.scheme = Some(scheme))
     }
 

--- a/src/transport_layer/transport_layer.rs
+++ b/src/transport_layer/transport_layer.rs
@@ -8,7 +8,7 @@ use ::std::fmt::Debug;
 use ::url::Url;
 
 #[async_trait]
-pub trait TransportLayer: Debug {
+pub trait TransportLayer: Debug + Send {
     async fn send(&mut self, request: Request<Body>) -> Result<(Parts, Bytes)>;
     fn url<'a>(&'a self) -> Option<&'a Url> {
         None


### PR DESCRIPTION
# Changes

 * `TransportLayer` now requires `Send`, this allows being created inside a `OnceCell` and other types.
