### PR TITLE
feat: TypedRoute support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ default = ["pretty-assertions"]
 msgpack = ["dep:rmp-serde"]
 pretty-assertions = ["dep:pretty_assertions"]
 yaml = ["dep:serde_yaml"]
+typed-routing = ["dep:axum-extra"]
 
 [dependencies]
 auto-future = "1.0"
 axum = { version = "0.7", features = ["tokio"] }
+axum-extra = { version = "TODO", features = ["typed-routing"], optional = true }
 anyhow = "1.0"
 bytes = "1.6"
 cookie = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["pretty-assertions"]
+all = ["msgpack", "pretty-assertions", "yaml", "typed-routing"]
+
 msgpack = ["dep:rmp-serde"]
 pretty-assertions = ["dep:pretty_assertions"]
 yaml = ["dep:serde_yaml"]
@@ -26,7 +28,7 @@ typed-routing = ["dep:axum-extra"]
 [dependencies]
 auto-future = "1.0"
 axum = { version = "0.7", features = ["tokio"] }
-axum-extra = { version = "TODO", features = ["typed-routing"], optional = true }
+axum-extra = { version = "0.9", features = ["typed-routing"], optional = true }
 anyhow = "1.0"
 bytes = "1.6"
 cookie = "0.18"
@@ -44,20 +46,20 @@ serde_json = "1.0"
 serde_yaml = { version = "0.9", optional = true }
 serde_urlencoded = "0.7"
 smallvec = "1.13"
-tokio = { version = "1.37", features = ["rt", "time"] }
+tokio = { version = "1.38", features = ["rt", "time"] }
 tower = { version = "0.4", features = ["util", "make"] }
 url = "2.5"
 
 [dev-dependencies]
 async-trait = "0.1"
 axum = { version = "0.7", features = ["multipart", "tokio"] }
-axum-extra = { version = "0.9", features = ["cookie", "query"] }
+axum-extra = { version = "0.9", features = ["cookie", "typed-routing", "query"] }
 axum-msgpack = "0.4"
 axum-yaml = "0.4"
 local-ip-address = "0.6"
 regex = "1.10"
 serde-email = { version = "3.0", features = ["serde"] }
-tokio = { version = "1.37", features = ["rt", "rt-multi-thread", "time", "macros"] }
+tokio = { version = "1.38", features = ["rt", "rt-multi-thread", "time", "macros"] }
 
 [[example]]
 name = "example-todo"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Here are a list of all features so far that can be enabled:
  * `pretty-assertions` **on by default**, uses the [pretty assertions crate](https://crates.io/crates/pretty_assertions) for the output to the `assert_*` functions.
  * `yaml` _off by default_, adds support for sending, receiving, and asserting, [yaml content](https://yaml.org/).
  * `msgpack` _off by default_, adds support for sending, receiving, and asserting, [msgpack content](https://msgpack.org/index.html).
+ * `axum-extra` _off by default_, adds support for the `TypedPath` from [axum-extra](https://crates.io/crates/axum-extra).
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Querying your application on the `TestServer` supports all of the common request
 
 Here are a list of all features so far that can be enabled:
 
+ * `all` _off by default_, turns on all features below.
  * `pretty-assertions` **on by default**, uses the [pretty assertions crate](https://crates.io/crates/pretty_assertions) for the output to the `assert_*` functions.
  * `yaml` _off by default_, adds support for sending, receiving, and asserting, [yaml content](https://yaml.org/).
  * `msgpack` _off by default_, adds support for sending, receiving, and asserting, [msgpack content](https://msgpack.org/index.html).

--- a/src/internals/query_params_store.rs
+++ b/src/internals/query_params_store.rs
@@ -5,7 +5,7 @@ use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct QueryParamsStore {
     query_params: SmallVec<[String; 0]>,
 }
@@ -57,5 +57,40 @@ impl Display for QueryParamsStore {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test_add_raw {
+    use super::QueryParamsStore;
+
+    #[test]
+    fn it_should_add_key_value_pairs_correctly() {
+        let mut params = QueryParamsStore::new();
+
+        params.add_raw("key=value".to_string());
+        params.add_raw("another=value".to_string());
+
+        assert_eq!("key=value&another=value", params.to_string());
+    }
+
+    #[test]
+    fn it_should_add_single_keys_correctly() {
+        let mut params = QueryParamsStore::new();
+
+        params.add_raw("key".to_string());
+        params.add_raw("another".to_string());
+
+        assert_eq!("key&another", params.to_string());
+    }
+
+    #[test]
+    fn it_should_add_query_param_strings_correctly() {
+        let mut params = QueryParamsStore::new();
+
+        params.add_raw("key=value&another=value".to_string());
+        params.add_raw("more=value".to_string());
+
+        assert_eq!("key=value&another=value&more=value", params.to_string());
     }
 }

--- a/src/internals/request_path_formatter.rs
+++ b/src/internals/request_path_formatter.rs
@@ -23,10 +23,6 @@ impl<'a> RequestPathFormatter<'a> {
             query_params,
         }
     }
-
-    pub fn method(&self) -> &Method {
-        self.method
-    }
 }
 
 impl<'a> fmt::Display for RequestPathFormatter<'a> {

--- a/src/internals/request_path_formatter.rs
+++ b/src/internals/request_path_formatter.rs
@@ -1,6 +1,6 @@
+use super::QueryParamsStore;
 use ::http::Method;
 use ::std::fmt;
-use super::QueryParamsStore;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct RequestPathFormatter<'a> {
@@ -12,7 +12,11 @@ pub struct RequestPathFormatter<'a> {
 }
 
 impl<'a> RequestPathFormatter<'a> {
-    pub fn new(method: &'a Method, user_requested_path: &'a str, query_params: Option<&'a QueryParamsStore>) -> Self {
+    pub fn new(
+        method: &'a Method,
+        user_requested_path: &'a str,
+        query_params: Option<&'a QueryParamsStore>,
+    ) -> Self {
         Self {
             method,
             user_requested_path,
@@ -33,7 +37,7 @@ impl<'a> fmt::Display for RequestPathFormatter<'a> {
         match self.query_params {
             None => {
                 write!(f, "{method} {user_requested_path}")
-            },
+            }
             Some(query_params) => {
                 if query_params.is_empty() {
                     write!(f, "{method} {user_requested_path}")

--- a/src/internals/request_path_formatter.rs
+++ b/src/internals/request_path_formatter.rs
@@ -1,33 +1,47 @@
 use ::http::Method;
 use ::std::fmt;
+use super::QueryParamsStore;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct RequestPathFormatter {
-    method: Method,
+pub struct RequestPathFormatter<'a> {
+    method: &'a Method,
 
     /// This is the path that the user requested.
-    user_requested_path: String,
+    user_requested_path: &'a str,
+    query_params: Option<&'a QueryParamsStore>,
 }
 
-impl RequestPathFormatter {
-    pub fn new(method: Method, user_requested_path: String) -> Self {
+impl<'a> RequestPathFormatter<'a> {
+    pub fn new(method: &'a Method, user_requested_path: &'a str, query_params: Option<&'a QueryParamsStore>) -> Self {
         Self {
             method,
             user_requested_path,
+            query_params,
         }
     }
 
     pub fn method(&self) -> &Method {
-        &self.method
+        self.method
     }
 }
 
-impl fmt::Display for RequestPathFormatter {
+impl<'a> fmt::Display for RequestPathFormatter<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let method = &self.method;
         let user_requested_path = &self.user_requested_path;
 
-        write!(f, "{method} {user_requested_path}")
+        match self.query_params {
+            None => {
+                write!(f, "{method} {user_requested_path}")
+            },
+            Some(query_params) => {
+                if query_params.is_empty() {
+                    write!(f, "{method} {user_requested_path}")
+                } else {
+                    write!(f, "{method} {user_requested_path}?{query_params}")
+                }
+            }
+        }
     }
 }
 
@@ -37,9 +51,30 @@ mod test_fmt {
 
     #[test]
     fn it_should_format_with_path_given() {
-        let debug = RequestPathFormatter::new(Method::GET, "/donkeys".to_string());
+        let query_params = QueryParamsStore::new();
+        let debug = RequestPathFormatter::new(&Method::GET, &"/donkeys", Some(&query_params));
         let output = format!("{}", debug);
 
         assert_eq!(output, "GET /donkeys");
+    }
+
+    #[test]
+    fn it_should_format_with_path_given_and_no_query_params() {
+        let debug = RequestPathFormatter::new(&Method::GET, &"/donkeys", None);
+        let output = format!("{}", debug);
+
+        assert_eq!(output, "GET /donkeys");
+    }
+
+    #[test]
+    fn it_should_format_with_path_given_and_query_params() {
+        let mut query_params = QueryParamsStore::new();
+        query_params.add_raw("value=123".to_string());
+        query_params.add_raw("another-value".to_string());
+
+        let debug = RequestPathFormatter::new(&Method::GET, &"/donkeys", Some(&query_params));
+        let output = format!("{}", debug);
+
+        assert_eq!(output, "GET /donkeys?value=123&another-value");
     }
 }

--- a/src/internals/transport_layer/http_transport_layer.rs
+++ b/src/internals/transport_layer/http_transport_layer.rs
@@ -42,7 +42,10 @@ impl HttpTransportLayer {
 }
 
 impl TransportLayer for HttpTransportLayer {
-    fn send<'a>(&'a self, request: Request<Body>) -> Pin<Box<dyn 'a + Future<Output = Result<(Parts, Bytes)>>>> {
+    fn send<'a>(
+        &'a self,
+        request: Request<Body>,
+    ) -> Pin<Box<dyn 'a + Future<Output = Result<(Parts, Bytes)>>>> {
         Box::pin(async {
             let client = Client::builder(hyper_util::rt::TokioExecutor::new()).build_http();
             let hyper_response = client.request(request).await?;

--- a/src/internals/transport_layer/mock_transport_layer.rs
+++ b/src/internals/transport_layer/mock_transport_layer.rs
@@ -35,7 +35,10 @@ where
     AnyhowError: From<S::Error>,
     S::Future: Send,
 {
-    fn send<'a>(&'a self, request: Request<Body>) -> Pin<Box<dyn 'a + Future<Output = Result<(Parts, Bytes)>>>> {
+    fn send<'a>(
+        &'a self,
+        request: Request<Body>,
+    ) -> Pin<Box<dyn 'a + Future<Output = Result<(Parts, Bytes)>>>> {
         Box::pin(async {
             let body: Body = Bytes::new().into();
             let empty_request = Request::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,8 +467,8 @@ mod integrated_test_cookie_saving {
 mod integrated_test_typed_routing_and_query {
     use super::*;
 
-    use ::axum::Router;
     use ::axum::extract::Query;
+    use ::axum::Router;
     use ::axum_extra::routing::RouterExt;
     use ::axum_extra::routing::TypedPath;
     use ::serde::Deserialize;
@@ -483,7 +483,7 @@ mod integrated_test_typed_routing_and_query {
     #[derive(Serialize, Deserialize)]
     struct QueryParams {
         param: String,
-        other: Option<String>
+        other: Option<String>,
     }
 
     async fn route_get_with_param(
@@ -499,16 +499,13 @@ mod integrated_test_typed_routing_and_query {
     }
 
     fn new_app() -> Router {
-        Router::new()
-            .typed_get(route_get_with_param)
+        Router::new().typed_get(route_get_with_param)
     }
 
     #[tokio::test]
     async fn it_should_send_typed_get_with_query_params() {
         let server = TestServer::new(new_app()).unwrap();
-        let path = TestingPathQuery {
-            id: 123,
-        }.with_query_params(QueryParams {
+        let path = TestingPathQuery { id: 123 }.with_query_params(QueryParams {
             param: "with-typed-query".to_string(),
             other: None,
         });
@@ -523,9 +520,7 @@ mod integrated_test_typed_routing_and_query {
     #[tokio::test]
     async fn it_should_send_typed_get_with_added_query_param() {
         let server = TestServer::new(new_app()).unwrap();
-        let path = TestingPathQuery {
-            id: 123,
-        };
+        let path = TestingPathQuery { id: 123 };
 
         server
             .typed_get(&path)
@@ -538,9 +533,7 @@ mod integrated_test_typed_routing_and_query {
     #[tokio::test]
     async fn it_should_send_both_typed_and_added_query() {
         let server = TestServer::new(new_app()).unwrap();
-        let path = TestingPathQuery {
-            id: 123,
-        }.with_query_params(QueryParams {
+        let path = TestingPathQuery { id: 123 }.with_query_params(QueryParams {
             param: "with-typed-query".to_string(),
             other: None,
         });
@@ -551,5 +544,22 @@ mod integrated_test_typed_routing_and_query {
             .expect_success()
             .await
             .assert_text("get 123, with-typed-query&with-added-query");
+    }
+
+    #[tokio::test]
+    async fn it_should_send_replaced_query_when_cleared() {
+        let server = TestServer::new(new_app()).unwrap();
+        let path = TestingPathQuery { id: 123 }.with_query_params(QueryParams {
+            param: "with-typed-query".to_string(),
+            other: Some("with-typed-other".to_string()),
+        });
+
+        server
+            .typed_get(&path)
+            .clear_query_params()
+            .add_query_param("param", "with-added-query")
+            .expect_success()
+            .await
+            .assert_text("get 123, with-added-query");
     }
 }

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -390,10 +390,14 @@ impl TestRequest {
     where
         V: Serialize,
     {
-        self.config.query_params
+        self.config
+            .query_params
             .add(query_params)
             .with_context(|| {
-                format!("It should serialize query parameters, for request {}", self.debug_request_format())
+                format!(
+                    "It should serialize query parameters, for request {}",
+                    self.debug_request_format()
+                )
             })
             .unwrap();
 
@@ -534,7 +538,8 @@ impl TestRequest {
         let expected_state = self.expected_state;
         let save_cookies = self.config.is_saving_cookies;
         let body = self.body.unwrap_or(Body::empty());
-        let url = Self::build_url_query_params(self.config.full_request_url, &self.config.query_params);
+        let url =
+            Self::build_url_query_params(self.config.full_request_url, &self.config.query_params);
 
         let request = Self::build_request(
             method.clone(),
@@ -582,9 +587,7 @@ impl TestRequest {
         headers: Vec<(HeaderName, HeaderValue)>,
         debug_request_format: &str,
     ) -> Result<Request<Body>> {
-        let mut request_builder = Request::builder()
-            .uri(url.as_str())
-            .method(method);
+        let mut request_builder = Request::builder().uri(url.as_str()).method(method);
 
         // Add all the headers we have.
         if let Some(content_type) = content_type {
@@ -621,7 +624,11 @@ impl TestRequest {
     }
 
     fn debug_request_format<'a>(&'a self) -> RequestPathFormatter<'a> {
-        RequestPathFormatter::new(&self.config.method, &self.config.full_request_url.as_str(), Some(&self.config.query_params))
+        RequestPathFormatter::new(
+            &self.config.method,
+            &self.config.full_request_url.as_str(),
+            Some(&self.config.query_params),
+        )
     }
 }
 
@@ -643,7 +650,7 @@ impl TryFrom<TestRequest> for Request<Body> {
             test_request.config.content_type,
             test_request.config.cookies,
             test_request.config.headers,
-            &debug_request_format
+            &debug_request_format,
         )
     }
 }

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -12,9 +12,9 @@ use ::http::header;
 use ::http::header::SET_COOKIE;
 use ::http::HeaderName;
 use ::http::HeaderValue;
+use ::http::Method;
 use ::http::Request;
 use ::serde::Serialize;
-use ::std::convert::AsRef;
 use ::std::fmt::Debug;
 use ::std::fmt::Display;
 use ::std::future::IntoFuture;
@@ -96,9 +96,6 @@ pub struct TestRequest {
     transport: Arc<Box<dyn TransportLayer>>,
 
     body: Option<Body>,
-    headers: Vec<(HeaderName, HeaderValue)>,
-    cookies: CookieJar,
-    query_params: QueryParamsStore,
 
     expected_state: ExpectedState,
 }
@@ -107,38 +104,17 @@ impl TestRequest {
     pub(crate) fn new(
         server_state: Arc<Mutex<ServerSharedState>>,
         transport: Arc<Box<dyn TransportLayer>>,
-        mut config: TestRequestConfig,
-    ) -> Result<Self> {
+        config: TestRequestConfig,
+    ) -> Self {
         let expected_state = config.expected_state;
-        let server_locked = server_state.as_ref().lock().map_err(|err| {
-            let request_format = &config.request_format;
-            anyhow!(
-                "Failed to lock InternalTestServer, for request {request_format}, received {err:?}",
-            )
-        })?;
 
-        if let Some(scheme) = server_locked.scheme() {
-            config.full_request_url.set_scheme(scheme).map_err(|_| {
-                anyhow!("Scheme '{scheme}' from TestServer cannot be set to request")
-            })?;
-        }
-
-        let cookies = server_locked.cookies().clone();
-        let query_params = server_locked.query_params().clone();
-        let headers = server_locked.headers().clone();
-
-        ::std::mem::drop(server_locked);
-
-        Ok(Self {
+        Self {
             config,
             server_state,
             transport,
             body: None,
-            headers,
-            cookies,
-            query_params,
             expected_state,
-        })
+        }
     }
 
     /// Set the body of the request to send up data as Json,
@@ -288,14 +264,14 @@ impl TestRequest {
 
     /// Adds a Cookie to be sent with this request.
     pub fn add_cookie<'c>(mut self, cookie: Cookie<'c>) -> Self {
-        self.cookies.add(cookie.into_owned());
+        self.config.cookies.add(cookie.into_owned());
         self
     }
 
     /// Adds many cookies to be used with this request.
     pub fn add_cookies(mut self, cookies: CookieJar) -> Self {
         for cookie in cookies.iter() {
-            self.cookies.add(cookie.clone());
+            self.config.cookies.add(cookie.clone());
         }
 
         self
@@ -304,7 +280,7 @@ impl TestRequest {
     /// Clears all cookies used internally within this Request,
     /// including any that came from the `TestServer`.
     pub fn clear_cookies(mut self) -> Self {
-        self.cookies = CookieJar::new();
+        self.config.cookies = CookieJar::new();
         self
     }
 
@@ -414,11 +390,10 @@ impl TestRequest {
     where
         V: Serialize,
     {
-        self.query_params
+        self.config.query_params
             .add(query_params)
             .with_context(|| {
-                let request_format = &self.config.request_format;
-                format!("It should serialize query parameters, for request {request_format}")
+                format!("It should serialize query parameters, for request {}", self.debug_request_format())
             })
             .unwrap();
 
@@ -450,7 +425,7 @@ impl TestRequest {
     /// ```
     ///
     pub fn add_raw_query_param(mut self, query_param: &str) -> Self {
-        self.query_params.add_raw(query_param.to_string());
+        self.config.query_params.add_raw(query_param.to_string());
 
         self
     }
@@ -458,19 +433,19 @@ impl TestRequest {
     /// Clears all query params set,
     /// including any that came from the [`TestServer`](crate::TestServer).
     pub fn clear_query_params(mut self) -> Self {
-        self.query_params.clear();
+        self.config.query_params.clear();
         self
     }
 
     /// Adds a header to be sent with this request.
     pub fn add_header<'c>(mut self, name: HeaderName, value: HeaderValue) -> Self {
-        self.headers.push((name, value));
+        self.config.headers.push((name, value));
         self
     }
 
     /// Clears all headers set.
     pub fn clear_headers(mut self) -> Self {
-        self.headers = vec![];
+        self.config.headers = vec![];
         self
     }
 
@@ -553,31 +528,31 @@ impl TestRequest {
     }
 
     async fn send(mut self) -> Result<TestResponse> {
+        let debug_request_format = self.debug_request_format().to_string();
+
+        let method = self.config.method;
         let expected_state = self.expected_state;
         let save_cookies = self.config.is_saving_cookies;
         let body = self.body.unwrap_or(Body::empty());
-        let request_format = self.config.request_format;
+        let url = Self::build_url_query_params(self.config.full_request_url, &self.config.query_params);
 
-        let url = Self::build_url_query_params(self.config.full_request_url, &self.query_params);
         let request = Self::build_request(
-            &request_format,
+            method.clone(),
             &url,
             body,
             self.config.content_type,
-            self.cookies,
-            self.headers,
+            self.config.cookies,
+            self.config.headers,
+            &debug_request_format,
         )?;
-
-        let (parts, response_bytes) = {
-            self.transport.send(request).await?
-        };
+        let (parts, response_bytes) = self.transport.send(request).await?;
 
         if save_cookies {
             let cookie_headers = parts.headers.get_all(SET_COOKIE).into_iter();
             ServerSharedState::add_cookies_by_header(&mut self.server_state, cookie_headers)?;
         }
 
-        let response = TestResponse::new(request_format, url, parts, response_bytes);
+        let response = TestResponse::new(method, url, parts, response_bytes);
 
         // Assert if ok or not.
         match expected_state {
@@ -599,21 +574,22 @@ impl TestRequest {
     }
 
     fn build_request(
-        request_format: &RequestPathFormatter,
+        method: Method,
         url: &Url,
         body: Body,
         content_type: Option<String>,
         cookies: CookieJar,
         headers: Vec<(HeaderName, HeaderValue)>,
+        debug_request_format: &str,
     ) -> Result<Request<Body>> {
         let mut request_builder = Request::builder()
             .uri(url.as_str())
-            .method(request_format.method().clone());
+            .method(method);
 
         // Add all the headers we have.
         if let Some(content_type) = content_type {
             let (header_key, header_value) =
-                build_content_type_header(&content_type, &request_format)?;
+                build_content_type_header(&content_type, &debug_request_format)?;
             request_builder = request_builder.header(header_key, header_value);
         }
 
@@ -638,10 +614,14 @@ impl TestRequest {
         }
 
         let request = request_builder.body(body).with_context(|| {
-            format!("Expect valid hyper Request to be built, for request {request_format}")
+            format!("Expect valid hyper Request to be built, for request {debug_request_format}")
         })?;
 
         Ok(request)
+    }
+
+    fn debug_request_format<'a>(&'a self) -> RequestPathFormatter<'a> {
+        RequestPathFormatter::new(&self.config.method, &self.config.full_request_url.as_str(), Some(&self.config.query_params))
     }
 }
 
@@ -649,19 +629,21 @@ impl TryFrom<TestRequest> for Request<Body> {
     type Error = AnyhowError;
 
     fn try_from(test_request: TestRequest) -> Result<Request<Body>> {
+        let debug_request_format = test_request.debug_request_format().to_string();
         let url = TestRequest::build_url_query_params(
             test_request.config.full_request_url,
-            &test_request.query_params,
+            &test_request.config.query_params,
         );
         let body = test_request.body.unwrap_or(Body::empty());
 
         TestRequest::build_request(
-            &test_request.config.request_format,
+            test_request.config.method,
             &url,
             body,
             test_request.config.content_type,
-            test_request.cookies,
-            test_request.headers,
+            test_request.config.cookies,
+            test_request.config.headers,
+            &debug_request_format
         )
     }
 }
@@ -682,11 +664,11 @@ impl IntoFuture for TestRequest {
 
 fn build_content_type_header(
     content_type: &str,
-    request_format: &RequestPathFormatter,
+    debug_request_format: &str,
 ) -> Result<(HeaderName, HeaderValue)> {
     let header_value = HeaderValue::from_str(content_type).with_context(|| {
         format!(
-            "Failed to store header content type '{content_type}', for request {request_format}"
+            "Failed to store header content type '{content_type}', for request {debug_request_format}"
         )
     })?;
 

--- a/src/test_request/test_request_config.rs
+++ b/src/test_request/test_request_config.rs
@@ -1,7 +1,11 @@
+use ::cookie::CookieJar;
+use ::http::HeaderName;
+use ::http::HeaderValue;
+use ::http::Method;
 use ::url::Url;
 
 use crate::internals::ExpectedState;
-use crate::internals::RequestPathFormatter;
+use crate::internals::QueryParamsStore;
 
 #[derive(Debug, Clone)]
 pub struct TestRequestConfig {
@@ -9,5 +13,9 @@ pub struct TestRequestConfig {
     pub expected_state: ExpectedState,
     pub content_type: Option<String>,
     pub full_request_url: Url,
-    pub request_format: RequestPathFormatter,
+    pub method: Method,
+
+    pub cookies: CookieJar,
+    pub query_params: QueryParamsStore,
+    pub headers: Vec<(HeaderName, HeaderValue)>,
 }

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -547,7 +547,9 @@ impl TestResponse {
                 .with_context(|| {
                     let debug_request_format = self.debug_request_format();
 
-                    format!("Reading header 'Set-Cookie' as string, for request {debug_request_format}",)
+                    format!(
+                        "Reading header 'Set-Cookie' as string, for request {debug_request_format}",
+                    )
                 })
                 .unwrap();
 

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -184,7 +184,50 @@ impl TestServer {
 
     /// Creates a HTTP GET request, using the typed path provided.
     ///
-    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on [`TypedPath`](axum_extra::routing::TypedPath).
+    ///
+    /// # Example Test
+    ///
+    /// Using a `TypedPath` you can write build and test a route like below:
+    ///
+    /// ```rust
+    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// #
+    /// use ::axum::Json;
+    /// use ::axum::routing::Router;
+    /// use ::axum::routing::get;
+    /// use ::axum_extra::routing::RouterExt;
+    /// use ::axum_extra::routing::TypedPath;
+    /// use ::serde::Deserialize;
+    /// use ::serde::Serialize;
+    ///
+    /// use ::axum_test::TestServer;
+    ///
+    /// #[derive(TypedPath, Deserialize)]
+    /// #[typed_path("/users/:user_id")]
+    /// struct UserPath {
+    ///     pub user_id: u32,
+    /// }
+    ///
+    /// // Build a typed route:
+    /// async fn route_get_user(UserPath { user_id }: UserPath) -> String {
+    ///     format!("hello user {user_id}")
+    /// }
+    ///
+    /// let app = Router::new()
+    ///     .typed_get(route_get_user);
+    ///
+    /// // Then test the route:
+    /// let server = TestServer::new(app)?;
+    /// server
+    ///     .typed_get(&UserPath { user_id: 123 })
+    ///     .await
+    ///     .assert_text("hello user 123");
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
     #[cfg(feature = "typed-routing")]
     pub fn typed_get<P>(&self, path: &P) -> TestRequest
     where
@@ -195,7 +238,7 @@ impl TestServer {
 
     /// Creates a HTTP POST request, using the typed path provided.
     ///
-    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on [`TypedPath`](axum_extra::routing::TypedPath).
     #[cfg(feature = "typed-routing")]
     pub fn typed_post<P>(&self, path: &P) -> TestRequest
     where
@@ -206,7 +249,7 @@ impl TestServer {
 
     /// Creates a HTTP PATCH request, using the typed path provided.
     ///
-    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on [`TypedPath`](axum_extra::routing::TypedPath).
     #[cfg(feature = "typed-routing")]
     pub fn typed_patch<P>(&self, path: &P) -> TestRequest
     where
@@ -217,7 +260,7 @@ impl TestServer {
 
     /// Creates a HTTP PUT request, using the typed path provided.
     ///
-    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on [`TypedPath`](axum_extra::routing::TypedPath).
     #[cfg(feature = "typed-routing")]
     pub fn typed_put<P>(&self, path: &P) -> TestRequest
     where
@@ -228,7 +271,7 @@ impl TestServer {
 
     /// Creates a HTTP DELETE request, using the typed path provided.
     ///
-    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on [`TypedPath`](axum_extra::routing::TypedPath).
     #[cfg(feature = "typed-routing")]
     pub fn typed_delete<P>(&self, path: &P) -> TestRequest
     where
@@ -239,7 +282,7 @@ impl TestServer {
 
     /// Creates a typed HTTP request, using the method provided.
     ///
-    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on [`TypedPath`](axum_extra::routing::TypedPath).
     #[cfg(feature = "typed-routing")]
     pub fn typed_method<P>(&self, method: Method, path: &P) -> TestRequest
     where
@@ -1691,10 +1734,10 @@ mod test_typed_get {
     async fn it_should_send_get() {
         let server = TestServer::new(new_app()).unwrap();
 
-        server
-            .typed_get(&TestingPath { id: 123 })
-            .await
-            .assert_text("get 123");
+server
+    .typed_get(&TestingPath { id: 123 })
+    .await
+    .assert_text("get 123");
     }
 }
 

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -10,6 +10,9 @@ use ::std::sync::Arc;
 use ::std::sync::Mutex;
 use ::url::Url;
 
+#[cfg(feature = "typed-routing")]
+use ::axum_extra::routing::TypedPath;
+
 use crate::internals::ExpectedState;
 use crate::transport_layer::IntoTransportLayer;
 use crate::transport_layer::TransportLayer;
@@ -176,6 +179,72 @@ impl TestServer {
                 format!("Trying to create internal request, for request {method} {path}")
             })
             .unwrap()
+    }
+
+    /// Creates a HTTP GET request, using the typed path provided.
+    ///
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    #[cfg(feature = "typed-routing")]
+    pub fn typed_get<P>(&slf, method: Method, path: &P) -> TestRequest
+    where
+        P: TypedPath
+    {
+        self.typed_method(Method::GET, path)
+    }
+
+    /// Creates a HTTP POST request, using the typed path provided.
+    ///
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    #[cfg(feature = "typed-routing")]
+    pub fn typed_post<P>(&slf, method: Method, path: &P) -> TestRequest
+    where
+        P: TypedPath
+    {
+        self.typed_method(Method::POST, path)
+    }
+
+    /// Creates a HTTP PATCH request, using the typed path provided.
+    ///
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    #[cfg(feature = "typed-routing")]
+    pub fn typed_patch<P>(&slf, method: Method, path: &P) -> TestRequest
+    where
+        P: TypedPath
+    {
+        self.typed_method(Method::PATCH, path)
+    }
+
+    /// Creates a HTTP PUT request, using the typed path provided.
+    ///
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    #[cfg(feature = "typed-routing")]
+    pub fn typed_put<P>(&slf, method: Method, path: &P) -> TestRequest
+    where
+        P: TypedPath
+    {
+        self.typed_method(Method::PUT, path)
+    }
+
+    /// Creates a HTTP DELETE request, using the typed path provided.
+    ///
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    #[cfg(feature = "typed-routing")]
+    pub fn typed_delete<P>(&slf, method: Method, path: &P) -> TestRequest
+    where
+        P: TypedPath
+    {
+        self.typed_method(Method::DELETE, path)
+    }
+
+    /// Creates a typed HTTP request, using the method provided.
+    ///
+    /// See [`axum-extra`](https://docs.rs/axum-extra) for full documentation on `TypedPath`.
+    #[cfg(feature = "typed-routing")]
+    pub fn typed_method<P>(&slf, method: Method, path: &P) -> TestRequest
+    where
+        P: TypedPath
+    {
+        self.method(method, &path.to_string())
     }
 
     /// Returns the local web address for the test server,
@@ -1373,5 +1442,297 @@ mod test_scheme {
         server.get("/scheme").await.assert_text("https");
 
         server.get("/scheme").await.assert_text("https");
+    }
+}
+
+#[cfg(feature = "typed-routing")]
+#[cfg(test)]
+mod test_typed_get {
+    use super::*;
+
+    use ::axum::extract::Query;
+    use ::serde::Deserialize;
+
+    #[derive(TypedPath, Deserialize)]
+    #[typed_path("/path/:id")]
+    struct TestingPath {
+        id: u32,
+    }
+
+    async fn route_get(
+        TestingPath { id }: TestingPath,
+        Query(params): Query<QueryParams>,
+    ) -> String {
+        format!("get {id}")
+    }
+
+    fn new_app() -> Router {
+        Router::new()
+            .typed_get(route_get)
+    }
+
+    #[tokio::test]
+    async fn it_should_send_get() {
+        let server = TestServer::new(new_app()).await.unwrap();
+
+        server
+            .typed_get(&TestingPath {
+                id: 123,
+            })
+            .await
+            .assert_text("get 123");
+    }
+}
+
+#[cfg(feature = "typed-routing")]
+#[cfg(test)]
+mod test_typed_post {
+    use super::*;
+
+    use ::serde::Deserialize;
+
+    #[derive(TypedPath, Deserialize)]
+    #[typed_path("/path/:id")]
+    struct TestingPath {
+        id: u32,
+    }
+
+    async fn route_post(
+        TestingPath { id }: TestingPath
+    ) -> String {
+        format!("post {id}")
+    }
+
+    fn new_app() -> Router {
+        Router::new()
+            .typed_post(route_post)
+    }
+
+    #[tokio::test]
+    async fn it_should_send_post() {
+        let server = TestServer::new(new_app()).await.unwrap();
+
+        server
+            .typed_post(&TestingPath {
+                id: 123,
+            })
+            .await
+            .assert_text("post 123");
+    }
+}
+
+#[cfg(feature = "typed-routing")]
+#[cfg(test)]
+mod test_typed_patch {
+    use super::*;
+
+    use ::serde::Deserialize;
+
+    #[derive(TypedPath, Deserialize)]
+    #[typed_path("/path/:id")]
+    struct TestingPath {
+        id: u32,
+    }
+
+    async fn route_patch(
+        TestingPath { id }: TestingPath
+    ) -> String {
+        format!("patch {id}")
+    }
+
+    fn new_app() -> Router {
+        Router::new()
+            .typed_patch(route_patch)
+    }
+
+    #[tokio::test]
+    async fn it_should_send_patch() {
+        let server = TestServer::new(new_app()).await.unwrap();
+
+        server
+            .typed_patch(&TestingPath {
+                id: 123,
+            })
+            .await
+            .assert_text("patch 123");
+    }
+}
+
+#[cfg(feature = "typed-routing")]
+#[cfg(test)]
+mod test_typed_put {
+    use super::*;
+
+    use ::serde::Deserialize;
+
+    #[derive(TypedPath, Deserialize)]
+    #[typed_path("/path/:id")]
+    struct TestingPath {
+        id: u32,
+    }
+
+    async fn route_put(
+        TestingPath { id }: TestingPath
+    ) -> String {
+        format!("put {id}")
+    }
+
+    fn new_app() -> Router {
+        Router::new()
+            .typed_put(route_put)
+    }
+
+    #[tokio::test]
+    async fn it_should_send_put() {
+        let server = TestServer::new(new_app()).await.unwrap();
+
+        server
+            .typed_put(&TestingPath {
+                id: 123,
+            })
+            .await
+            .assert_text("put 123");
+    }
+}
+
+#[cfg(feature = "typed-routing")]
+#[cfg(test)]
+mod test_typed_delete {
+    use super::*;
+
+    use ::serde::Deserialize;
+
+    #[derive(TypedPath, Deserialize)]
+    #[typed_path("/path/:id")]
+    struct TestingPath {
+        id: u32,
+    }
+
+    async fn route_delete(
+        TestingPath { id }: TestingPath
+    ) -> String {
+        format!("delete {id}")
+    }
+
+    fn new_app() -> Router {
+        Router::new()
+            .typed_delete(route_delete)
+    }
+
+    #[tokio::test]
+    async fn it_should_send_delete() {
+        let server = TestServer::new(new_app()).await.unwrap();
+
+        server
+            .typed_delete(&TestingPath {
+                id: 123,
+            })
+            .await
+            .assert_text("delete 123");
+    }
+}
+
+#[cfg(feature = "typed-routing")]
+#[cfg(test)]
+mod test_typed_method {
+    use super::*;
+
+    use ::serde::Deserialize;
+
+    #[derive(TypedPath, Deserialize)]
+    #[typed_path("/path/:id")]
+    struct TestingPath {
+        id: u32,
+    }
+
+    async fn route_get(
+        TestingPath { id }: TestingPath
+    ) -> String {
+        format!("get {id}")
+    }
+
+    async fn route_post(TestingPath { id }: TestingPath) -> String {
+        format!("post {id}")
+    }
+
+    async fn route_patch(TestingPath { id }: TestingPath) -> String {
+        format!("patch {id}")
+    }
+
+    async fn route_put(TestingPath { id }: TestingPath) -> String {
+        format!("put {id}")
+    }
+
+    async fn route_delete(TestingPath { id }: TestingPath) -> String {
+        format!("delete {id}")
+    }
+
+    fn new_app() -> Router {
+        Router::new()
+            .typed_get(route_get)
+            .typed_post(route_post)
+            .typed_patch(route_patch)
+            .typed_put(route_put)
+            .typed_delete(route_delete)
+    }
+
+    #[tokio::test]
+    async fn it_should_send_get() {
+        let server = TestServer::new(new_app()).await.unwrap();
+
+        server
+            .typed_method(Method::GET, &TestingPath {
+                id: 123,
+            })
+            .await
+            .assert_text("get 123");
+    }
+
+    #[tokio::test]
+    async fn it_should_send_post() {
+        let server = TestServer::new(new_app()).await.unwrap();
+
+        server
+            .typed_method(Method::POST, &TestingPath {
+                id: 123,
+            })
+            .await
+            .assert_text("post 123");
+    }
+
+    #[tokio::test]
+    async fn it_should_send_patch() {
+        let server = TestServer::new(new_app()).await.unwrap();
+
+        server
+            .typed_method(Method::PATCH, &TestingPath {
+                id: 123,
+            })
+            .await
+            .assert_text("patch 123");
+    }
+
+    #[tokio::test]
+    async fn it_should_send_put() {
+        let server = TestServer::new(new_app()).await.unwrap();
+
+        server
+            .typed_method(Method::PUT, &TestingPath {
+                id: 123,
+            })
+            .await
+            .assert_text("put 123");
+    }
+
+    #[tokio::test]
+    async fn it_should_send_delete() {
+        let server = TestServer::new(new_app()).await.unwrap();
+
+        server
+            .typed_method(Method::DELETE, &TestingPath {
+                id: 123,
+            })
+            .await
+            .assert_text("delete 123");
     }
 }

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -1734,10 +1734,10 @@ mod test_typed_get {
     async fn it_should_send_get() {
         let server = TestServer::new(new_app()).unwrap();
 
-server
-    .typed_get(&TestingPath { id: 123 })
-    .await
-    .assert_text("get 123");
+        server
+            .typed_get(&TestingPath { id: 123 })
+            .await
+            .assert_text("get 123");
     }
 }
 

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -26,8 +26,8 @@ use crate::Transport;
 
 mod server_shared_state;
 pub(crate) use self::server_shared_state::*;
-use crate::internals::RequestPathFormatter;
 use crate::internals::QueryParamsStore;
+use crate::internals::RequestPathFormatter;
 
 const DEFAULT_URL_ADDRESS: &'static str = "http://localhost";
 
@@ -176,9 +176,7 @@ impl TestServer {
     pub fn method(&self, method: Method, path: &str) -> TestRequest {
         let maybe_config = self.test_request_config(method.clone(), path);
         let config = maybe_config
-            .with_context(|| {
-                format!("Failed to build, for request {method} {path}")
-            })
+            .with_context(|| format!("Failed to build, for request {method} {path}"))
             .unwrap();
 
         TestRequest::new(self.state.clone(), self.transport.clone(), config)
@@ -190,7 +188,7 @@ impl TestServer {
     #[cfg(feature = "typed-routing")]
     pub fn typed_get<P>(&self, path: &P) -> TestRequest
     where
-        P: TypedPath
+        P: TypedPath,
     {
         self.typed_method(Method::GET, path)
     }
@@ -201,7 +199,7 @@ impl TestServer {
     #[cfg(feature = "typed-routing")]
     pub fn typed_post<P>(&self, path: &P) -> TestRequest
     where
-        P: TypedPath
+        P: TypedPath,
     {
         self.typed_method(Method::POST, path)
     }
@@ -212,7 +210,7 @@ impl TestServer {
     #[cfg(feature = "typed-routing")]
     pub fn typed_patch<P>(&self, path: &P) -> TestRequest
     where
-        P: TypedPath
+        P: TypedPath,
     {
         self.typed_method(Method::PATCH, path)
     }
@@ -223,7 +221,7 @@ impl TestServer {
     #[cfg(feature = "typed-routing")]
     pub fn typed_put<P>(&self, path: &P) -> TestRequest
     where
-        P: TypedPath
+        P: TypedPath,
     {
         self.typed_method(Method::PUT, path)
     }
@@ -234,7 +232,7 @@ impl TestServer {
     #[cfg(feature = "typed-routing")]
     pub fn typed_delete<P>(&self, path: &P) -> TestRequest
     where
-        P: TypedPath
+        P: TypedPath,
     {
         self.typed_method(Method::DELETE, path)
     }
@@ -245,7 +243,7 @@ impl TestServer {
     #[cfg(feature = "typed-routing")]
     pub fn typed_method<P>(&self, method: Method, path: &P) -> TestRequest
     where
-        P: TypedPath
+        P: TypedPath,
     {
         self.method(method, &path.to_string())
     }
@@ -398,7 +396,11 @@ impl TestServer {
         self.transport.url().map(|url| url.clone())
     }
 
-    pub(crate) fn test_request_config(&self, method: Method, path: &str) -> Result<TestRequestConfig> {
+    pub(crate) fn test_request_config(
+        &self,
+        method: Method,
+        path: &str,
+    ) -> Result<TestRequestConfig> {
         let url = self
             .url()
             .unwrap_or_else(|| DEFAULT_URL_ADDRESS.parse().unwrap());
@@ -412,7 +414,8 @@ impl TestServer {
         let cookies = server_locked.cookies().clone();
         let mut query_params = server_locked.query_params().clone();
         let headers = server_locked.headers().clone();
-        let mut full_request_url = build_url(url, path, &mut query_params, self.is_http_path_restricted)?;
+        let mut full_request_url =
+            build_url(url, path, &mut query_params, self.is_http_path_restricted)?;
 
         if let Some(scheme) = server_locked.scheme() {
             full_request_url.set_scheme(scheme).map_err(|_| {
@@ -437,7 +440,12 @@ impl TestServer {
     }
 }
 
-fn build_url(mut url: Url, path: &str, query_params: &mut QueryParamsStore, is_http_restricted: bool) -> Result<Url> {
+fn build_url(
+    mut url: Url,
+    path: &str,
+    query_params: &mut QueryParamsStore,
+    is_http_restricted: bool,
+) -> Result<Url> {
     let path_uri = path.parse::<Uri>()?;
     let is_not_allowed = is_path_blocked(&url, &path_uri, is_http_restricted);
 
@@ -448,20 +456,14 @@ fn build_url(mut url: Url, path: &str, query_params: &mut QueryParamsStore, is_h
     if !is_http_restricted {
         if let Some(scheme) = path_uri.scheme_str() {
             url.set_scheme(scheme)
-                .map_err(|_| {
-                    anyhow!("Failed to set scheme for request, with path '{path}'")
-                })?;
+                .map_err(|_| anyhow!("Failed to set scheme for request, with path '{path}'"))?;
         }
 
         if let Some(authority) = path_uri.authority() {
             url.set_host(Some(authority.host()))
-                .map_err(|_| {
-                    anyhow!("Failed to set host for request, with path '{path}'")
-                })?;
+                .map_err(|_| anyhow!("Failed to set host for request, with path '{path}'"))?;
             url.set_port(authority.port().map(|p| p.as_u16()))
-                .map_err(|_| {
-                    anyhow!("Failed to set port for request, with path '{path}'")
-                })?;
+                .map_err(|_| anyhow!("Failed to set port for request, with path '{path}'"))?;
 
             // todo, add username:password support
         }
@@ -1605,15 +1607,12 @@ mod test_typed_get {
         id: u32,
     }
 
-    async fn route_get(
-        TestingPath { id }: TestingPath,
-    ) -> String {
+    async fn route_get(TestingPath { id }: TestingPath) -> String {
         format!("get {id}")
     }
 
     fn new_app() -> Router {
-        Router::new()
-            .typed_get(route_get)
+        Router::new().typed_get(route_get)
     }
 
     #[tokio::test]
@@ -1621,9 +1620,7 @@ mod test_typed_get {
         let server = TestServer::new(new_app()).unwrap();
 
         server
-            .typed_get(&TestingPath {
-                id: 123,
-            })
+            .typed_get(&TestingPath { id: 123 })
             .await
             .assert_text("get 123");
     }
@@ -1644,15 +1641,12 @@ mod test_typed_post {
         id: u32,
     }
 
-    async fn route_post(
-        TestingPath { id }: TestingPath
-    ) -> String {
+    async fn route_post(TestingPath { id }: TestingPath) -> String {
         format!("post {id}")
     }
 
     fn new_app() -> Router {
-        Router::new()
-            .typed_post(route_post)
+        Router::new().typed_post(route_post)
     }
 
     #[tokio::test]
@@ -1660,9 +1654,7 @@ mod test_typed_post {
         let server = TestServer::new(new_app()).unwrap();
 
         server
-            .typed_post(&TestingPath {
-                id: 123,
-            })
+            .typed_post(&TestingPath { id: 123 })
             .await
             .assert_text("post 123");
     }
@@ -1683,15 +1675,12 @@ mod test_typed_patch {
         id: u32,
     }
 
-    async fn route_patch(
-        TestingPath { id }: TestingPath
-    ) -> String {
+    async fn route_patch(TestingPath { id }: TestingPath) -> String {
         format!("patch {id}")
     }
 
     fn new_app() -> Router {
-        Router::new()
-            .typed_patch(route_patch)
+        Router::new().typed_patch(route_patch)
     }
 
     #[tokio::test]
@@ -1699,9 +1688,7 @@ mod test_typed_patch {
         let server = TestServer::new(new_app()).unwrap();
 
         server
-            .typed_patch(&TestingPath {
-                id: 123,
-            })
+            .typed_patch(&TestingPath { id: 123 })
             .await
             .assert_text("patch 123");
     }
@@ -1722,15 +1709,12 @@ mod test_typed_put {
         id: u32,
     }
 
-    async fn route_put(
-        TestingPath { id }: TestingPath
-    ) -> String {
+    async fn route_put(TestingPath { id }: TestingPath) -> String {
         format!("put {id}")
     }
 
     fn new_app() -> Router {
-        Router::new()
-            .typed_put(route_put)
+        Router::new().typed_put(route_put)
     }
 
     #[tokio::test]
@@ -1738,9 +1722,7 @@ mod test_typed_put {
         let server = TestServer::new(new_app()).unwrap();
 
         server
-            .typed_put(&TestingPath {
-                id: 123,
-            })
+            .typed_put(&TestingPath { id: 123 })
             .await
             .assert_text("put 123");
     }
@@ -1761,15 +1743,12 @@ mod test_typed_delete {
         id: u32,
     }
 
-    async fn route_delete(
-        TestingPath { id }: TestingPath
-    ) -> String {
+    async fn route_delete(TestingPath { id }: TestingPath) -> String {
         format!("delete {id}")
     }
 
     fn new_app() -> Router {
-        Router::new()
-            .typed_delete(route_delete)
+        Router::new().typed_delete(route_delete)
     }
 
     #[tokio::test]
@@ -1777,9 +1756,7 @@ mod test_typed_delete {
         let server = TestServer::new(new_app()).unwrap();
 
         server
-            .typed_delete(&TestingPath {
-                id: 123,
-            })
+            .typed_delete(&TestingPath { id: 123 })
             .await
             .assert_text("delete 123");
     }
@@ -1800,9 +1777,7 @@ mod test_typed_method {
         id: u32,
     }
 
-    async fn route_get(
-        TestingPath { id }: TestingPath
-    ) -> String {
+    async fn route_get(TestingPath { id }: TestingPath) -> String {
         format!("get {id}")
     }
 
@@ -1836,9 +1811,7 @@ mod test_typed_method {
         let server = TestServer::new(new_app()).unwrap();
 
         server
-            .typed_method(Method::GET, &TestingPath {
-                id: 123,
-            })
+            .typed_method(Method::GET, &TestingPath { id: 123 })
             .await
             .assert_text("get 123");
     }
@@ -1848,9 +1821,7 @@ mod test_typed_method {
         let server = TestServer::new(new_app()).unwrap();
 
         server
-            .typed_method(Method::POST, &TestingPath {
-                id: 123,
-            })
+            .typed_method(Method::POST, &TestingPath { id: 123 })
             .await
             .assert_text("post 123");
     }
@@ -1860,9 +1831,7 @@ mod test_typed_method {
         let server = TestServer::new(new_app()).unwrap();
 
         server
-            .typed_method(Method::PATCH, &TestingPath {
-                id: 123,
-            })
+            .typed_method(Method::PATCH, &TestingPath { id: 123 })
             .await
             .assert_text("patch 123");
     }
@@ -1872,9 +1841,7 @@ mod test_typed_method {
         let server = TestServer::new(new_app()).unwrap();
 
         server
-            .typed_method(Method::PUT, &TestingPath {
-                id: 123,
-            })
+            .typed_method(Method::PUT, &TestingPath { id: 123 })
             .await
             .assert_text("put 123");
     }
@@ -1884,9 +1851,7 @@ mod test_typed_method {
         let server = TestServer::new(new_app()).unwrap();
 
         server
-            .typed_method(Method::DELETE, &TestingPath {
-                id: 123,
-            })
+            .typed_method(Method::DELETE, &TestingPath { id: 123 })
             .await
             .assert_text("delete 123");
     }

--- a/src/transport_layer/transport_layer.rs
+++ b/src/transport_layer/transport_layer.rs
@@ -4,12 +4,15 @@ use ::bytes::Bytes;
 use ::http::response::Parts;
 use ::http::Request;
 use ::std::fmt::Debug;
-use ::url::Url;
 use ::std::future::Future;
 use ::std::pin::Pin;
+use ::url::Url;
 
 pub trait TransportLayer: Debug + Send {
-    fn send<'a>(&'a self, request: Request<Body>) -> Pin<Box<dyn 'a + Future<Output = Result<(Parts, Bytes)>>>>;
+    fn send<'a>(
+        &'a self,
+        request: Request<Body>,
+    ) -> Pin<Box<dyn 'a + Future<Output = Result<(Parts, Bytes)>>>>;
     fn url<'a>(&'a self) -> Option<&'a Url> {
         None
     }

--- a/test.sh
+++ b/test.sh
@@ -4,5 +4,5 @@ set -e
 
 cargo check
 cargo test --example=example-todo
-cargo test  --features yaml,msgpack,pretty-assertions "$@"
+cargo test  --features all "$@"
 cargo test "$@"


### PR DESCRIPTION
# Changes

 * Rewrite of route path to allow query parameters in requests. i.e. `server.get("/users?limit=10")`
 * Add support for `axum-extra` `TypedPath`
