### PR TITLE
fix: parallel requests blocking server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "14.10.0"
+version = "15.0.0"
+rust-version = "1.75"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"
@@ -22,7 +23,6 @@ pretty-assertions = ["dep:pretty_assertions"]
 yaml = ["dep:serde_yaml"]
 
 [dependencies]
-async-trait = "0.1"
 auto-future = "1.0"
 axum = { version = "0.7", features = ["tokio"] }
 anyhow = "1.0"
@@ -47,6 +47,7 @@ tower = { version = "0.4", features = ["util", "make"] }
 url = "2.5"
 
 [dev-dependencies]
+async-trait = "0.1"
 axum = { version = "0.7", features = ["multipart", "tokio"] }
 axum-extra = { version = "0.9", features = ["cookie", "query"] }
 axum-msgpack = "0.4"

--- a/src/internals/transport_layer/mock_transport_layer.rs
+++ b/src/internals/transport_layer/mock_transport_layer.rs
@@ -1,6 +1,5 @@
 use ::anyhow::Error as AnyhowError;
 use ::anyhow::Result;
-use ::async_trait::async_trait;
 use ::axum::body::Body;
 use ::axum::Router;
 use ::bytes::Bytes;
@@ -8,6 +7,8 @@ use ::http::response::Parts;
 use ::http::Request;
 use ::http_body_util::BodyExt;
 use ::std::fmt::Debug;
+use ::std::future::Future;
+use ::std::pin::Pin;
 use ::tower::util::ServiceExt;
 use ::tower::Service;
 
@@ -28,27 +29,28 @@ where
     }
 }
 
-#[async_trait]
 impl<S> TransportLayer for MockTransportLayer<S>
 where
     S: Service<Request<Body>, Response = Router> + Clone + Send,
     AnyhowError: From<S::Error>,
     S::Future: Send,
 {
-    async fn send(&mut self, request: Request<Body>) -> Result<(Parts, Bytes)> {
-        let body: Body = Bytes::new().into();
-        let empty_request = Request::builder()
-            .body(body)
-            .expect("should build empty request");
+    fn send<'a>(&'a self, request: Request<Body>) -> Pin<Box<dyn 'a + Future<Output = Result<(Parts, Bytes)>>>> {
+        Box::pin(async {
+            let body: Body = Bytes::new().into();
+            let empty_request = Request::builder()
+                .body(body)
+                .expect("should build empty request");
 
-        let service = self.service.clone();
-        let router = service.oneshot(empty_request).await?;
+            let service = self.service.clone();
+            let router = service.oneshot(empty_request).await?;
 
-        let response = router.oneshot(request).await?;
-        let (parts, response_body) = response.into_parts();
-        let response_bytes = response_body.collect().await?.to_bytes();
+            let response = router.oneshot(request).await?;
+            let (parts, response_body) = response.into_parts();
+            let response_bytes = response_body.collect().await?.to_bytes();
 
-        Ok((parts, response_bytes))
+            Ok((parts, response_bytes))
+        })
     }
 }
 

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -93,7 +93,7 @@ pub struct TestRequest {
     config: TestRequestConfig,
 
     server_state: Arc<Mutex<ServerSharedState>>,
-    transport: Arc<Mutex<Box<dyn TransportLayer>>>,
+    transport: Arc<Box<dyn TransportLayer>>,
 
     body: Option<Body>,
     headers: Vec<(HeaderName, HeaderValue)>,
@@ -106,7 +106,7 @@ pub struct TestRequest {
 impl TestRequest {
     pub(crate) fn new(
         server_state: Arc<Mutex<ServerSharedState>>,
-        transport: Arc<Mutex<Box<dyn TransportLayer>>>,
+        transport: Arc<Box<dyn TransportLayer>>,
         mut config: TestRequestConfig,
     ) -> Result<Self> {
         let expected_state = config.expected_state;
@@ -569,12 +569,7 @@ impl TestRequest {
         )?;
 
         let (parts, response_bytes) = {
-            let mut transport_locked = self.transport.as_ref().lock().map_err(|err| {
-                anyhow!(
-                    "Expect Response to succeed, for request {request_format}, received {err:?}"
-                )
-            })?;
-            transport_locked.send(request).await?
+            self.transport.send(request).await?
         };
 
         if save_cookies {

--- a/src/transport_layer/transport_layer.rs
+++ b/src/transport_layer/transport_layer.rs
@@ -1,15 +1,15 @@
 use ::anyhow::Result;
-use ::async_trait::async_trait;
 use ::axum::body::Body;
 use ::bytes::Bytes;
 use ::http::response::Parts;
 use ::http::Request;
 use ::std::fmt::Debug;
 use ::url::Url;
+use ::std::future::Future;
+use ::std::pin::Pin;
 
-#[async_trait]
 pub trait TransportLayer: Debug + Send {
-    async fn send(&mut self, request: Request<Body>) -> Result<(Parts, Bytes)>;
+    fn send<'a>(&'a self, request: Request<Body>) -> Pin<Box<dyn 'a + Future<Output = Result<(Parts, Bytes)>>>>;
     fn url<'a>(&'a self) -> Option<&'a Url> {
         None
     }


### PR DESCRIPTION
# Changes

Fixes making multiple parallel requests to the `TestServer` at once.
This was due to a lock around the transport layer.

The fix is to remove the need for the lock, and then remove the lock entirely.

 * `TestServer.transport` is no longer wrapped in a `Mutex`.
 * `TransportLayer` no longer has mutable methods.
 * Dropped `async_trait`.
 * Added requirement for Rust 1.75.
