### PR TITLE
feat: extra utility functions for requests and responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "15.1.0"
+version = "15.2.0"
 rust-version = "1.75"
 edition = "2021"
 license = "MIT"

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -449,16 +449,25 @@ impl TestRequest {
     }
 
     /// Adds an 'AUTHORIZATION' HTTP header to the request,
+    /// with no internal formatting of what is given.
+    pub fn authorization<T>(self, authorization_header: T) -> Self
+    where
+        T: AsRef<str>,
+    {
+        let authorization_header_value = HeaderValue::from_str(authorization_header.as_ref())
+            .expect("Cannot build Authorization HeaderValue from token");
+
+        self.add_header(header::AUTHORIZATION, authorization_header_value)
+    }
+
+    /// Adds an 'AUTHORIZATION' HTTP header to the request,
     /// in the 'Bearer {token}' format.
-    pub fn add_authorization_bearer<T>(self, token: T) -> Self
+    pub fn authorization_bearer<T>(self, authorization_bearer_token: T) -> Self
     where
         T: Display,
     {
-        let authorization_bearer_str = format!("Bearer {token}");
-        let authorization_bearer_header = HeaderValue::from_str(&authorization_bearer_str)
-            .expect("Cannot build Authorization Bearer value from token");
-
-        self.add_header(header::AUTHORIZATION, authorization_bearer_header)
+        let authorization_bearer_header_str = format!("Bearer {authorization_bearer_token}");
+        self.authorization(authorization_bearer_header_str)
     }
 
     /// Clears all headers set.
@@ -1574,7 +1583,69 @@ mod test_add_header {
 }
 
 #[cfg(test)]
-mod test_add_authorization_bearer {
+mod test_authorization {
+    use super::*;
+
+    use ::axum::async_trait;
+    use ::axum::extract::FromRequestParts;
+    use ::axum::routing::get;
+    use ::axum::Router;
+    use ::http::request::Parts;
+    use ::hyper::StatusCode;
+    use ::std::marker::Sync;
+
+    use crate::TestServer;
+
+    fn new_test_server() -> TestServer {
+        struct TestHeader(String);
+
+        #[async_trait]
+        impl<S: Sync> FromRequestParts<S> for TestHeader {
+            type Rejection = (StatusCode, &'static str);
+
+            async fn from_request_parts(
+                parts: &mut Parts,
+                _state: &S,
+            ) -> Result<TestHeader, Self::Rejection> {
+                parts
+                    .headers
+                    .get(header::AUTHORIZATION)
+                    .map(|v| TestHeader(v.to_str().unwrap().to_string()))
+                    .ok_or((StatusCode::BAD_REQUEST, "Missing test header"))
+            }
+        }
+
+        async fn ping_auth_header(TestHeader(header): TestHeader) -> String {
+            header
+        }
+
+        // Build an application with a route.
+        let app = Router::new().route("/auth-header", get(ping_auth_header));
+
+        // Run the server.
+        let mut server = TestServer::new(app).expect("Should create test server");
+        server.expect_success();
+
+        server
+    }
+
+    #[tokio::test]
+    async fn it_should_send_header_added_to_request() {
+        let server = new_test_server();
+
+        // Send a request with the header
+        let response = server
+            .get(&"/auth-header")
+            .authorization("Bearer abc123")
+            .await;
+
+        // Check it sent back the right text
+        response.assert_text("Bearer abc123")
+    }
+}
+
+#[cfg(test)]
+mod test_authorization_bearer {
     use super::*;
 
     use ::axum::async_trait;
@@ -1615,8 +1686,7 @@ mod test_add_authorization_bearer {
 
         // Run the server.
         let mut server = TestServer::new(app).expect("Should create test server");
-        server
-            .expect_success();
+        server.expect_success();
 
         server
     }
@@ -1628,7 +1698,7 @@ mod test_add_authorization_bearer {
         // Send a request with the header
         let response = server
             .get(&"/auth-header")
-            .add_authorization_bearer("abc123")
+            .authorization_bearer("abc123")
             .await;
 
         // Check it sent back the right text


### PR DESCRIPTION
# Changes

 * Add `TestResponse::assert_text_contains`
 * Add `TestWebSocket::assert_receive_text_contains`
 * Add `TestRequest::authorization`
 * Add `TestRequest::authorization_bearer`

# Comments

Adding a few nice utility functions.
