### PR TITLE
feat: generate random tokio::net::TcpListener

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -6,3 +6,6 @@ pub use self::new_random_socket_addr::*;
 
 mod new_random_tcp_listener;
 pub use self::new_random_tcp_listener::*;
+
+mod new_random_tokio_tcp_listener;
+pub use self::new_random_tokio_tcp_listener::*;

--- a/src/util/new_random_tcp_listener.rs
+++ b/src/util/new_random_tcp_listener.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 
 pub(crate) const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
-/// Binds a `TcpListener` on the IP 127.0.0.1, using a random port.
+/// Binds a [`std::net::TcpListener`] on the IP 127.0.0.1, using a random port.
 ///
 /// This is the best way to pick a local port.
 pub fn new_random_tcp_listener() -> Result<TcpListener> {
@@ -15,9 +15,9 @@ pub fn new_random_tcp_listener() -> Result<TcpListener> {
     Ok(tcp_listener)
 }
 
-/// Binds a `TcpListener` on the IP 127.0.0.1, using a random port.
+/// Binds a [`std::net::TcpListener`] on the IP 127.0.0.1, using a random port.
 ///
-/// It is returned with the `SocketAddr` available.
+/// It is returned with the [`std::net::SocketAddr`] available.
 pub fn new_random_tcp_listener_with_socket_addr() -> Result<(TcpListener, SocketAddr)> {
     let result = ReservedPort::random_permanently_reserved_tcp(DEFAULT_IP_ADDRESS)?;
     Ok(result)

--- a/src/util/new_random_tokio_tcp_listener.rs
+++ b/src/util/new_random_tokio_tcp_listener.rs
@@ -1,0 +1,29 @@
+use ::anyhow::Result;
+use ::reserve_port::ReservedPort;
+use ::std::net::IpAddr;
+use ::std::net::Ipv4Addr;
+use ::tokio::net::TcpListener as TokioTcpListener;
+use std::net::SocketAddr;
+
+pub(crate) const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+/// Binds a [`tokio::net::TcpListener`] on the IP 127.0.0.1, using a random port.
+///
+/// This is the best way to pick a local port.
+pub fn new_random_tokio_tcp_listener() -> Result<TokioTcpListener> {
+    new_random_tokio_tcp_listener_with_socket_addr()
+        .map(|(tokio_tcp_listener, _)| tokio_tcp_listener)
+}
+
+/// Binds a [`tokio::net::TcpListener`] on the IP 127.0.0.1, using a random port.
+///
+/// It is returned with the [`std::net::SocketAddr`] available.
+pub fn new_random_tokio_tcp_listener_with_socket_addr() -> Result<(TokioTcpListener, SocketAddr)> {
+    let (tcp_listener, random_socket) =
+        ReservedPort::random_permanently_reserved_tcp(DEFAULT_IP_ADDRESS)?;
+
+    tcp_listener.set_nonblocking(true);
+    let tokio_tcp_listener = TokioTcpListener::from_std(tcp_listener)?;
+
+    Ok((tokio_tcp_listener, random_socket))
+}


### PR DESCRIPTION
# Changes

 * add `util::new_random_tokio_tcp_listener`
 * add `util::new_random_tokio_tcp_listener_with_socket_addr`

# Comments

This adds Tokio versions of building a `TcpListener`. This is useful as the Tokio variants are actually what we want when using Axum.

