### PR TITLE
feat: add support for building TestServer from Shuttle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["pretty-assertions"]
-all = ["pretty-assertions", "yaml", "msgpack", "typed-routing", "ws"]
+all = ["pretty-assertions", "yaml", "msgpack", "shuttle", "typed-routing", "ws"]
 
 pretty-assertions = ["dep:pretty_assertions"]
 yaml = ["dep:serde_yaml"]
 msgpack = ["dep:rmp-serde"]
+shuttle = ["dep:shuttle-axum"]
 typed-routing = ["dep:axum-extra"]
 ws = ["axum/ws", "dep:uuid", "dep:base64", "dep:tokio-tungstenite", "dep:futures-util"]
 
@@ -50,6 +51,9 @@ url = "2.5"
 
 # Yaml
 serde_yaml = { version = "0.9", optional = true }
+
+# Shuttle
+shuttle-axum = { version = "0.47", optional = true }
 
 # MsgPack
 rmp-serde = { version = "1.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Here are a list of all features so far that can be enabled:
  * `pretty-assertions` **on by default**, uses the [pretty assertions crate](https://crates.io/crates/pretty_assertions) for the output to the `assert_*` functions.
  * `yaml` _off by default_, adds support for sending, receiving, and asserting, [yaml content](https://yaml.org/).
  * `msgpack` _off by default_, adds support for sending, receiving, and asserting, [msgpack content](https://msgpack.org/index.html).
+ * `shuttle` _off by default_, adds support for building a `TestServer` from [`shuttle_axum::AxumService`](https://docs.rs/shuttle-axum/latest/shuttle_axum/struct.AxumService.html), for use with [Shuttle.rs](https://shuttle.rs).
  * `typed-routing` _off by default_, adds support for the `TypedPath` from [axum-extra](https://crates.io/crates/axum-extra).
  * `ws` _off by default_, adds support for WebSockets.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,9 @@
 //!  * `pretty-assertions` **on by default**, uses the [pretty assertions crate](https://crates.io/crates/pretty_assertions) for the output to the `assert_*` functions.
 //!  * `yaml` _off by default_, adds support for sending, receiving, and asserting, [yaml content](https://yaml.org/).
 //!  * `msgpack` _off by default_, adds support for sending, receiving, and asserting, [msgpack content](https://msgpack.org/index.html).
-//!  * `axum-extra` _off by default_, adds support for the `TypedPath` from [axum-extra](https://crates.io/crates/axum-extra).
+//!  * `shuttle` _off by default_, adds support for building a `TestServer` from [`shuttle_axum::AxumService`](https://docs.rs/shuttle-axum/latest/shuttle_axum/struct.AxumService.html), for use with [Shuttle.rs](https://shuttle.rs).
+//!  * `typed-routing` _off by default_, adds support for the `TypedPath` from [axum-extra](https://crates.io/crates/axum-extra).
+//!  * `ws` _off by default_, adds support for WebSockets.
 //!
 //! ## Features
 //!

--- a/src/transport_layer/into_transport_layer.rs
+++ b/src/transport_layer/into_transport_layer.rs
@@ -7,6 +7,11 @@ mod into_make_service;
 mod into_make_service_with_connect_info;
 mod router;
 
+#[cfg(feature = "shuttle")]
+mod axum_service;
+#[cfg(feature = "shuttle")]
+mod shuttle_axum;
+
 ///
 /// This exists to unify how to send mock or real messages to different services.
 /// This includes differences between [`Router`](::axum::routing::Router),

--- a/src/transport_layer/into_transport_layer/axum_service.rs
+++ b/src/transport_layer/into_transport_layer/axum_service.rs
@@ -1,0 +1,86 @@
+use ::anyhow::Result;
+use ::axum::Router;
+use ::shuttle_axum::AxumService;
+
+use super::IntoTransportLayer;
+use crate::transport_layer::TransportLayer;
+use crate::transport_layer::TransportLayerBuilder;
+
+impl IntoTransportLayer for AxumService {
+    fn into_http_transport_layer(
+        self,
+        builder: TransportLayerBuilder,
+    ) -> Result<Box<dyn TransportLayer>> {
+        Router::into_http_transport_layer(self.0, builder)
+    }
+
+    fn into_mock_transport_layer(self) -> Result<Box<dyn TransportLayer>> {
+        Router::into_mock_transport_layer(self.0)
+    }
+}
+
+#[cfg(test)]
+mod test_into_http_transport_layer_for_axum_service {
+    use super::*;
+
+    use ::axum::extract::State;
+    use ::axum::routing::get;
+    use ::axum::Router;
+
+    use crate::TestServerConfig;
+
+    async fn get_state(State(count): State<u32>) -> String {
+        format!("count is {}", count)
+    }
+
+    #[tokio::test]
+    async fn it_should_run() {
+        // Build an application with a route.
+        let app: AxumService = Router::new()
+            .route("/count", get(get_state))
+            .with_state(123)
+            .into();
+
+        // Run the server.
+        let server = TestServerConfig::builder()
+            .http_transport()
+            .build_server(app)
+            .expect("Should create test server");
+
+        // Get the request.
+        server.get(&"/count").await.assert_text(&"count is 123");
+    }
+}
+
+#[cfg(test)]
+mod test_into_mock_transport_layer_for_axum_service {
+    use super::*;
+
+    use ::axum::extract::State;
+    use ::axum::routing::get;
+    use ::axum::Router;
+
+    use crate::TestServerConfig;
+
+    async fn get_state(State(count): State<u32>) -> String {
+        format!("count is {}", count)
+    }
+
+    #[tokio::test]
+    async fn it_should_run() {
+        // Build an application with a route.
+        let app: AxumService = Router::new()
+            .route("/count", get(get_state))
+            .with_state(123)
+            .into();
+
+        // Run the server.
+        let server = TestServerConfig::builder()
+            .mock_transport()
+            .build_server(app)
+            .expect("Should create test server");
+
+        // Get the request.
+        server.get(&"/count").await.assert_text(&"count is 123");
+    }
+}

--- a/src/transport_layer/into_transport_layer/into_make_service.rs
+++ b/src/transport_layer/into_transport_layer/into_make_service.rs
@@ -55,9 +55,7 @@ mod test_into_http_transport_layer_for_into_make_service {
     use ::axum::routing::IntoMakeService;
     use ::axum::Router;
 
-    use crate::TestServer;
     use crate::TestServerConfig;
-    use crate::Transport;
 
     async fn get_ping() -> &'static str {
         "pong!"
@@ -75,11 +73,10 @@ mod test_into_http_transport_layer_for_into_make_service {
             .into_make_service();
 
         // Run the server.
-        let config = TestServerConfig {
-            transport: Some(Transport::HttpRandomPort),
-            ..TestServerConfig::default()
-        };
-        let server = TestServer::new_with_config(app, config).expect("Should create test server");
+        let server = TestServerConfig::builder()
+            .http_transport()
+            .build_server(app)
+            .expect("Should create test server");
 
         // Get the request.
         server.get(&"/ping").await.assert_text(&"pong!");
@@ -94,11 +91,10 @@ mod test_into_http_transport_layer_for_into_make_service {
             .into_make_service();
 
         // Run the server.
-        let config = TestServerConfig {
-            transport: Some(Transport::HttpRandomPort),
-            ..TestServerConfig::default()
-        };
-        let server = TestServer::new_with_config(app, config).expect("Should create test server");
+        let server = TestServerConfig::builder()
+            .http_transport()
+            .build_server(app)
+            .expect("Should create test server");
 
         // Get the request.
         server.get(&"/count").await.assert_text(&"count is 123");
@@ -112,9 +108,7 @@ mod test_into_mock_transport_layer_for_into_make_service {
     use ::axum::routing::IntoMakeService;
     use ::axum::Router;
 
-    use crate::TestServer;
     use crate::TestServerConfig;
-    use crate::Transport;
 
     async fn get_ping() -> &'static str {
         "pong!"
@@ -132,11 +126,10 @@ mod test_into_mock_transport_layer_for_into_make_service {
             .into_make_service();
 
         // Run the server.
-        let config = TestServerConfig {
-            transport: Some(Transport::MockHttp),
-            ..TestServerConfig::default()
-        };
-        let server = TestServer::new_with_config(app, config).expect("Should create test server");
+        let server = TestServerConfig::builder()
+            .mock_transport()
+            .build_server(app)
+            .expect("Should create test server");
 
         // Get the request.
         server.get(&"/ping").await.assert_text(&"pong!");
@@ -151,11 +144,10 @@ mod test_into_mock_transport_layer_for_into_make_service {
             .into_make_service();
 
         // Run the server.
-        let config = TestServerConfig {
-            transport: Some(Transport::MockHttp),
-            ..TestServerConfig::default()
-        };
-        let server = TestServer::new_with_config(app, config).expect("Should create test server");
+        let server = TestServerConfig::builder()
+            .mock_transport()
+            .build_server(app)
+            .expect("Should create test server");
 
         // Get the request.
         server.get(&"/count").await.assert_text(&"count is 123");

--- a/src/transport_layer/into_transport_layer/into_make_service_with_connect_info.rs
+++ b/src/transport_layer/into_transport_layer/into_make_service_with_connect_info.rs
@@ -62,9 +62,7 @@ mod test_into_http_transport_layer_for_into_make_service_with_connect_info {
     use ::axum::Router;
     use ::std::net::SocketAddr;
 
-    use crate::TestServer;
     use crate::TestServerConfig;
-    use crate::Transport;
 
     async fn get_ping() -> &'static str {
         "pong!"
@@ -78,11 +76,10 @@ mod test_into_http_transport_layer_for_into_make_service_with_connect_info {
             .into_make_service_with_connect_info::<SocketAddr>();
 
         // Run the server.
-        let config = TestServerConfig {
-            transport: Some(Transport::HttpRandomPort),
-            ..TestServerConfig::default()
-        };
-        let server = TestServer::new_with_config(app, config).expect("Should create test server");
+        let server = TestServerConfig::builder()
+            .http_transport()
+            .build_server(app)
+            .expect("Should create test server");
 
         // Get the request.
         server.get(&"/ping").await.assert_text(&"pong!");
@@ -95,9 +92,7 @@ mod test_into_mock_transport_layer_for_into_make_service_with_connect_info {
     use ::axum::Router;
     use ::std::net::SocketAddr;
 
-    use crate::TestServer;
     use crate::TestServerConfig;
-    use crate::Transport;
 
     async fn get_ping() -> &'static str {
         "pong!"
@@ -111,11 +106,9 @@ mod test_into_mock_transport_layer_for_into_make_service_with_connect_info {
             .into_make_service_with_connect_info::<SocketAddr>();
 
         // Build the server.
-        let config = TestServerConfig {
-            transport: Some(Transport::MockHttp),
-            ..TestServerConfig::default()
-        };
-        let result = TestServer::new_with_config(app, config);
+        let result = TestServerConfig::builder()
+            .mock_transport()
+            .build_server(app);
         let err = result.unwrap_err();
         let err_msg = format!("{}", err);
 

--- a/src/transport_layer/into_transport_layer/router.rs
+++ b/src/transport_layer/into_transport_layer/router.rs
@@ -24,9 +24,7 @@ mod test_into_http_transport_layer {
     use ::axum::routing::get;
     use ::axum::Router;
 
-    use crate::TestServer;
     use crate::TestServerConfig;
-    use crate::Transport;
 
     async fn get_ping() -> &'static str {
         "pong!"
@@ -42,11 +40,10 @@ mod test_into_http_transport_layer {
         let app: Router = Router::new().route("/ping", get(get_ping));
 
         // Run the server.
-        let config = TestServerConfig {
-            transport: Some(Transport::HttpRandomPort),
-            ..TestServerConfig::default()
-        };
-        let server = TestServer::new_with_config(app, config).expect("Should create test server");
+        let server = TestServerConfig::builder()
+            .http_transport()
+            .build_server(app)
+            .expect("Should create test server");
 
         // Get the request.
         server.get(&"/ping").await.assert_text(&"pong!");
@@ -60,11 +57,10 @@ mod test_into_http_transport_layer {
             .with_state(123);
 
         // Run the server.
-        let config = TestServerConfig {
-            transport: Some(Transport::HttpRandomPort),
-            ..TestServerConfig::default()
-        };
-        let server = TestServer::new_with_config(app, config).expect("Should create test server");
+        let server = TestServerConfig::builder()
+            .http_transport()
+            .build_server(app)
+            .expect("Should create test server");
 
         // Get the request.
         server.get(&"/count").await.assert_text(&"count is 123");
@@ -77,9 +73,7 @@ mod test_into_mock_transport_layer_for_router {
     use ::axum::routing::get;
     use ::axum::Router;
 
-    use crate::TestServer;
     use crate::TestServerConfig;
-    use crate::Transport;
 
     async fn get_ping() -> &'static str {
         "pong!"
@@ -95,11 +89,10 @@ mod test_into_mock_transport_layer_for_router {
         let app: Router = Router::new().route("/ping", get(get_ping));
 
         // Run the server.
-        let config = TestServerConfig {
-            transport: Some(Transport::MockHttp),
-            ..TestServerConfig::default()
-        };
-        let server = TestServer::new_with_config(app, config).expect("Should create test server");
+        let server = TestServerConfig::builder()
+            .mock_transport()
+            .build_server(app)
+            .expect("Should create test server");
 
         // Get the request.
         server.get(&"/ping").await.assert_text(&"pong!");
@@ -113,11 +106,10 @@ mod test_into_mock_transport_layer_for_router {
             .with_state(123);
 
         // Run the server.
-        let config = TestServerConfig {
-            transport: Some(Transport::MockHttp),
-            ..TestServerConfig::default()
-        };
-        let server = TestServer::new_with_config(app, config).expect("Should create test server");
+        let server = TestServerConfig::builder()
+            .mock_transport()
+            .build_server(app)
+            .expect("Should create test server");
 
         // Get the request.
         server.get(&"/count").await.assert_text(&"count is 123");

--- a/src/transport_layer/into_transport_layer/shuttle_axum.rs
+++ b/src/transport_layer/into_transport_layer/shuttle_axum.rs
@@ -1,0 +1,89 @@
+use ::anyhow::Result;
+use ::shuttle_axum::ShuttleAxum;
+
+use super::IntoTransportLayer;
+use crate::transport_layer::TransportLayer;
+use crate::transport_layer::TransportLayerBuilder;
+
+impl IntoTransportLayer for ShuttleAxum {
+    fn into_http_transport_layer(
+        self,
+        builder: TransportLayerBuilder,
+    ) -> Result<Box<dyn TransportLayer>> {
+        self.map_err(Into::into)
+            .and_then(|axum_service| axum_service.into_http_transport_layer(builder))
+    }
+
+    fn into_mock_transport_layer(self) -> Result<Box<dyn TransportLayer>> {
+        self.map_err(Into::into)
+            .and_then(|axum_service| axum_service.into_mock_transport_layer())
+    }
+}
+
+#[cfg(test)]
+mod test_into_http_transport_layer_for_shuttle_axum {
+    use super::*;
+
+    use ::axum::extract::State;
+    use ::axum::routing::get;
+    use ::axum::Router;
+    use ::shuttle_axum::AxumService;
+
+    use crate::TestServerConfig;
+
+    async fn get_state(State(count): State<u32>) -> String {
+        format!("count is {}", count)
+    }
+
+    #[tokio::test]
+    async fn it_should_run() {
+        // Build an application with a route.
+        let router = Router::new()
+            .route("/count", get(get_state))
+            .with_state(123);
+        let app: ShuttleAxum = Ok(AxumService::from(router));
+
+        // Run the server.
+        let server = TestServerConfig::builder()
+            .http_transport()
+            .build_server(app)
+            .expect("Should create test server");
+
+        // Get the request.
+        server.get(&"/count").await.assert_text(&"count is 123");
+    }
+}
+
+#[cfg(test)]
+mod test_into_mock_transport_layer_for_shuttle_axum {
+    use super::*;
+
+    use ::axum::extract::State;
+    use ::axum::routing::get;
+    use ::axum::Router;
+    use ::shuttle_axum::AxumService;
+
+    use crate::TestServerConfig;
+
+    async fn get_state(State(count): State<u32>) -> String {
+        format!("count is {}", count)
+    }
+
+    #[tokio::test]
+    async fn it_should_run() {
+        // Build an application with a route.
+        let router = Router::new()
+            .route("/count", get(get_state))
+            .with_state(123);
+        let app: ShuttleAxum = Ok(AxumService::from(router));
+
+        // Run the server.
+        let server = TestServerConfig::builder()
+            .mock_transport()
+            .build_server(app)
+            .expect("Should create test server");
+
+        // Get the request.
+        server.get(&"/count").await.assert_text(&"count is 123");
+    }
+}

--- a/test.sh
+++ b/test.sh
@@ -15,5 +15,6 @@ cargo check --features all
 cargo check --features pretty-assertions
 cargo check --features yaml
 cargo check --features msgpack
+cargo check --features shuttle
 cargo check --features typed-routing
 cargo check --features ws


### PR DESCRIPTION
This adds support for building a `TestServer` from Shuttle.

# Changes

 * `TestServer` can be built from `shuttle_axum::ShuttleAxum`.
 * `TestServer` can be built from `shuttle_axum::AxumService`.
