### PR TITLE
fix: change build_app to build_server in examples

### DIFF
--- a/examples/example-todo/main.rs
+++ b/examples/example-todo/main.rs
@@ -169,7 +169,7 @@ fn new_test_app() -> TestServer {
         .save_cookies()
         .expect_success_by_default()
         .mock_transport()
-        .build_app(app)
+        .build_server(app)
         .unwrap()
 }
 

--- a/examples/example-websocket-chat/main.rs
+++ b/examples/example-websocket-chat/main.rs
@@ -164,7 +164,7 @@ fn new_test_app() -> TestServer {
     let app = new_app();
     TestServerConfig::builder()
         .http_transport() // Important! It must be a HTTP Transport here.
-        .build_app(app)
+        .build_server(app)
         .unwrap()
 }
 

--- a/examples/example-websocket-ping-pong/main.rs
+++ b/examples/example-websocket-ping-pong/main.rs
@@ -73,7 +73,7 @@ fn new_test_app() -> TestServer {
     let app = new_app();
     TestServerConfig::builder()
         .http_transport() // Important! It must be a HTTP Transport here.
-        .build_app(app)
+        .build_server(app)
         .unwrap()
 }
 


### PR DESCRIPTION
# Changes

 * fix examples. Change `build_app` to `build_server`.

# Comments

I had renamed this in a previous commit and must have missed these examples.
