### PR TITLE
feat: header methods can now take many values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "15.5.4"
+version = "16.0.0"
 rust-version = "1.75"
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "16.0.0"
+version = "15.6.0"
 rust-version = "1.75"
 edition = "2021"
 license = "MIT"

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -443,8 +443,39 @@ impl TestRequest {
     }
 
     /// Adds a header to be sent with this request.
-    pub fn add_header<'c>(mut self, name: HeaderName, value: HeaderValue) -> Self {
-        self.config.headers.push((name, value));
+    ///
+    /// ```rust
+    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// #
+    /// use ::axum::Router;
+    /// use ::axum_test::TestServer;
+    ///
+    /// let app = Router::new();
+    /// let server = TestServer::new(app)?;
+    ///
+    /// let response = server.get(&"/my-end-point")
+    ///     .add_header("x-custom-header", "custom-value")
+    ///     .add_header(http::header::CONTENT_LENGTH, 12345)
+    ///     .add_header(http::header::HOST, "example.com")
+    ///     .await;
+    /// #
+    /// # Ok(()) }
+    /// ```
+    pub fn add_header<N, V>(mut self, name: N, value: V) -> Self
+    where
+        N: TryInto<HeaderName>,
+        N::Error: Debug,
+        V: TryInto<HeaderValue>,
+        V::Error: Debug,
+    {
+        let header_name: HeaderName = name
+            .try_into()
+            .expect("Failed to convert header name to HeaderName");
+        let header_value: HeaderValue = value
+            .try_into()
+            .expect("Failed to convert header vlue to HeaderValue");
+
+        self.config.headers.push((header_name, header_value));
         self
     }
 

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -58,9 +58,23 @@ mod test_request_config;
 ///
 /// Once fully configured you send the request by awaiting the request object.
 ///
-/// ```rust,ignore
-/// let request = server.get(&"/user");
+/// ```rust
+/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// #
+/// # use ::axum::Router;
+/// # use ::axum_test::TestServer;
+/// #
+/// # let server = TestServer::new(Router::new())?;
+/// #
+/// // Build your request
+/// let request = server.get(&"/user")
+///     .add_header("x-custom-header", "example.com")
+///     .content_type("application/yaml");
+///
+/// // await request to execute
 /// let response = request.await;
+/// #
+/// # Ok(()) }
 /// ```
 ///
 /// You will receive a `TestResponse`.

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -509,6 +509,25 @@ impl TestServer {
     }
 
     /// Adds a header to be sent with all future requests built from this `TestServer`.
+    ///
+    /// ```rust
+    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// #
+    /// use ::axum::Router;
+    /// use ::axum_test::TestServer;
+    ///
+    /// let app = Router::new();
+    /// let mut server = TestServer::new(app)?;
+    ///
+    /// server.add_header("x-custom-header", "custom-value");
+    /// server.add_header(http::header::CONTENT_LENGTH, 12345);
+    /// server.add_header(http::header::HOST, "example.com");
+    ///
+    /// let response = server.get(&"/my-end-point")
+    ///     .await;
+    /// #
+    /// # Ok(()) }
+    /// ```
     pub fn add_header<'c, N, V>(&mut self, name: N, value: V)
     where
         N: TryInto<HeaderName>,

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -8,6 +8,7 @@ use ::http::HeaderValue;
 use ::http::Method;
 use ::http::Uri;
 use ::serde::Serialize;
+use ::std::fmt::Debug;
 use ::std::sync::Arc;
 use ::std::sync::Mutex;
 use ::url::Url;
@@ -221,12 +222,12 @@ impl TestServer {
         use ::http::header;
 
         self.get(path)
-            .add_header(header::CONNECTION, "upgrade".parse().unwrap())
-            .add_header(header::UPGRADE, "websocket".parse().unwrap())
-            .add_header(header::SEC_WEBSOCKET_VERSION, "13".parse().unwrap())
+            .add_header(header::CONNECTION, "upgrade")
+            .add_header(header::UPGRADE, "websocket")
+            .add_header(header::SEC_WEBSOCKET_VERSION, "13")
             .add_header(
                 header::SEC_WEBSOCKET_KEY,
-                crate::internals::generate_ws_key().parse().unwrap(),
+                crate::internals::generate_ws_key(),
             )
     }
 
@@ -508,8 +509,21 @@ impl TestServer {
     }
 
     /// Adds a header to be sent with all future requests built from this `TestServer`.
-    pub fn add_header<'c>(&mut self, name: HeaderName, value: HeaderValue) {
-        ServerSharedState::add_header(&self.state, name, value)
+    pub fn add_header<'c, N, V>(&mut self, name: N, value: V)
+    where
+        N: TryInto<HeaderName>,
+        N::Error: Debug,
+        V: TryInto<HeaderValue>,
+        V::Error: Debug,
+    {
+        let header_name: HeaderName = name
+            .try_into()
+            .expect("Failed to convert header name to HeaderName");
+        let header_value: HeaderValue = value
+            .try_into()
+            .expect("Failed to convert header vlue to HeaderValue");
+
+        ServerSharedState::add_header(&self.state, header_name, header_value)
             .with_context(|| format!("Trying to call add_header"))
             .unwrap()
     }


### PR DESCRIPTION
These are some quality of life changes to improve working with headers, and simplify header code.

# Changes

 * `TestServer::add_header` can now take a wider array of types for the name and value, and converts internally.
 * `TestRequest::add_header` can now take a wider array of types for the name and value, and converts internally.
 * `TestResponse::maybe_header` can now take a wider array of types for the name, and converts internally.
 * `TestResponse::header` can now take a wider array of types for the name, and converts internally.
 * `TestResponse::iter_headers_by_name` can now take a wider array of types for the name, and converts internally.
 * `TestResponse::contains_header` can now take a wider array of types for the name, and converts internally.
 * `TestResponse::assert_contains_header` can now take a wider array of types for the name, and converts internally.
 * `TestResponse::assert_header` can now take a wider array of types for the name and value, and converts internally.
