### PR TITLE
feat: make into service generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "15.6.0"
+version = "15.7.0"
 rust-version = "1.75"
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde = { version = "1.0" }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 smallvec = "1.13"
-tokio = { version = "1.39", features = ["rt", "time"] }
+tokio = { version = "1.40", features = ["rt", "time"] }
 tower = { version = "0.5", features = ["util", "make"] }
 url = "2.5"
 
@@ -79,4 +79,5 @@ regex = "1.10"
 serde-email = { version = "3.0", features = ["serde"] }
 shuttle-axum = "0.47"
 shuttle-runtime = "0.47"
-tokio = { version = "1.39", features = ["rt", "rt-multi-thread", "time", "macros"] }
+tokio = { version = "1.40", features = ["rt", "rt-multi-thread", "time", "macros"] }
+tower-http = { version = "0.5", features = ["normalize-path"] }

--- a/src/transport_layer/into_transport_layer.rs
+++ b/src/transport_layer/into_transport_layer.rs
@@ -3,6 +3,8 @@ use ::anyhow::Result;
 use crate::transport_layer::TransportLayer;
 use crate::transport_layer::TransportLayerBuilder;
 
+// mod into_make_service_tower;
+
 mod into_make_service;
 mod into_make_service_with_connect_info;
 mod router;

--- a/src/transport_layer/transport_layer.rs
+++ b/src/transport_layer/transport_layer.rs
@@ -9,7 +9,7 @@ use ::url::Url;
 
 use crate::transport_layer::TransportLayerType;
 
-pub trait TransportLayer: Debug + Send + Sync {
+pub trait TransportLayer: Debug + Send {
     fn send<'a>(
         &'a self,
         request: Request<Body>,

--- a/src/util/spawn_serve.rs
+++ b/src/util/spawn_serve.rs
@@ -9,7 +9,7 @@ use ::tower::Service;
 
 use crate::util::ServeHandle;
 
-/// A wrapper around [`axum::serve`] for tests,
+/// A wrapper around [`axum::serve()`] for tests,
 /// which spawns the service in a new thread.
 ///
 /// The [`crate::util::ServeHandle`] returned will automatically attempt


### PR DESCRIPTION
# Changes

 * `IntoMakeService` support for transport layer is generic.
 * `IntoMakeServiceWithConnectInfo` support for transport layer is generic.

# Comments

This PR allows an `IntoMakeService` which holds any `Router` like service. Including ones that wrap a `Router`.

fixes #105 
