### PR TITLE
refactor: remove absolute imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Using this library, you can host your application and query against it with requ
 Then decode the responses, and assert what is returned.
 
 ```rust
-  use ::axum::Router;
-  use ::axum::routing::get;
+  use axum::Router;
+  use axum::routing::get;
 
-  use ::axum_test::TestServer;
+  use axum_test::TestServer;
 
   async fn get_ping() -> &'static str {
       "pong!"

--- a/examples/example-shuttle/main.rs
+++ b/examples/example-shuttle/main.rs
@@ -16,29 +16,29 @@
 //! At the bottom of this file are a series of tests for these endpoints.
 //!
 
-use ::anyhow::anyhow;
-use ::anyhow::Result;
-use ::axum::extract::Json;
-use ::axum::extract::State;
-use ::axum::routing::get;
-use ::axum::routing::post;
-use ::axum::routing::put;
-use ::axum::Router;
-use ::axum_extra::extract::cookie::Cookie;
-use ::axum_extra::extract::cookie::CookieJar;
-use ::http::StatusCode;
-use ::serde::Deserialize;
-use ::serde::Serialize;
-use ::serde_email::Email;
-use ::std::collections::HashMap;
-use ::std::result::Result as StdResult;
-use ::std::sync::Arc;
-use ::std::sync::RwLock;
+use anyhow::anyhow;
+use anyhow::Result;
+use axum::extract::Json;
+use axum::extract::State;
+use axum::routing::get;
+use axum::routing::post;
+use axum::routing::put;
+use axum::Router;
+use axum_extra::extract::cookie::Cookie;
+use axum_extra::extract::cookie::CookieJar;
+use http::StatusCode;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_email::Email;
+use std::collections::HashMap;
+use std::result::Result as StdResult;
+use std::sync::Arc;
+use std::sync::RwLock;
 
 #[cfg(test)]
-use ::axum_test::TestServer;
+use axum_test::TestServer;
 #[cfg(test)]
-use ::axum_test::TestServerConfig;
+use axum_test::TestServerConfig;
 
 /// Main to start Shuttle application
 #[shuttle_runtime::main]
@@ -166,7 +166,7 @@ pub async fn route_get_user_todos(
 mod test_post_login {
     use super::*;
 
-    use ::serde_json::json;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_create_session_on_login() {
@@ -205,7 +205,7 @@ mod test_post_login {
 mod test_route_put_user_todos {
     use super::*;
 
-    use ::serde_json::json;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_not_store_todos_without_login() {
@@ -260,7 +260,7 @@ mod test_route_put_user_todos {
 mod test_route_get_user_todos {
     use super::*;
 
-    use ::serde_json::json;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_not_return_todos_if_logged_out() {

--- a/examples/example-todo/main.rs
+++ b/examples/example-todo/main.rs
@@ -15,34 +15,34 @@
 //! At the bottom of this file are a series of tests for these endpoints.
 //!
 
-use ::anyhow::anyhow;
-use ::anyhow::Result;
-use ::axum::extract::Json;
-use ::axum::extract::State;
-use ::axum::routing::get;
-use ::axum::routing::post;
-use ::axum::routing::put;
-use ::axum::serve::serve;
-use ::axum::Router;
-use ::axum_extra::extract::cookie::Cookie;
-use ::axum_extra::extract::cookie::CookieJar;
-use ::http::StatusCode;
-use ::serde::Deserialize;
-use ::serde::Serialize;
-use ::serde_email::Email;
-use ::std::collections::HashMap;
-use ::std::net::IpAddr;
-use ::std::net::Ipv4Addr;
-use ::std::net::SocketAddr;
-use ::std::result::Result as StdResult;
-use ::std::sync::Arc;
-use ::std::sync::RwLock;
-use ::tokio::net::TcpListener;
+use anyhow::anyhow;
+use anyhow::Result;
+use axum::extract::Json;
+use axum::extract::State;
+use axum::routing::get;
+use axum::routing::post;
+use axum::routing::put;
+use axum::serve::serve;
+use axum::Router;
+use axum_extra::extract::cookie::Cookie;
+use axum_extra::extract::cookie::CookieJar;
+use http::StatusCode;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_email::Email;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use std::result::Result as StdResult;
+use std::sync::Arc;
+use std::sync::RwLock;
+use tokio::net::TcpListener;
 
 #[cfg(test)]
-use ::axum_test::TestServer;
+use axum_test::TestServer;
 #[cfg(test)]
-use ::axum_test::TestServerConfig;
+use axum_test::TestServerConfig;
 
 const PORT: u16 = 8080;
 const USER_ID_COOKIE_NAME: &'static str = &"example-todo-user-id";
@@ -182,7 +182,7 @@ fn new_test_app() -> TestServer {
 mod test_post_login {
     use super::*;
 
-    use ::serde_json::json;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_create_session_on_login() {
@@ -221,7 +221,7 @@ mod test_post_login {
 mod test_route_put_user_todos {
     use super::*;
 
-    use ::serde_json::json;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_not_store_todos_without_login() {
@@ -276,7 +276,7 @@ mod test_route_put_user_todos {
 mod test_route_get_user_todos {
     use super::*;
 
-    use ::serde_json::json;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_not_return_todos_if_logged_out() {

--- a/examples/example-websocket-chat/main.rs
+++ b/examples/example-websocket-chat/main.rs
@@ -9,33 +9,33 @@
 //! ```
 //!
 
-use ::anyhow::Result;
-use ::axum::extract::ws::Message;
-use ::axum::extract::ws::WebSocket;
-use ::axum::extract::Path;
-use ::axum::extract::State;
-use ::axum::extract::WebSocketUpgrade;
-use ::axum::response::Response;
-use ::axum::routing::get;
-use ::axum::serve::serve;
-use ::axum::Router;
-use ::futures_util::SinkExt;
-use ::futures_util::StreamExt;
-use ::serde::Deserialize;
-use ::serde::Serialize;
-use ::std::collections::HashMap;
-use ::std::net::IpAddr;
-use ::std::net::Ipv4Addr;
-use ::std::net::SocketAddr;
-use ::std::sync::Arc;
-use ::std::time::Duration;
-use ::tokio::net::TcpListener;
-use ::tokio::sync::RwLock;
+use anyhow::Result;
+use axum::extract::ws::Message;
+use axum::extract::ws::WebSocket;
+use axum::extract::Path;
+use axum::extract::State;
+use axum::extract::WebSocketUpgrade;
+use axum::response::Response;
+use axum::routing::get;
+use axum::serve::serve;
+use axum::Router;
+use futures_util::SinkExt;
+use futures_util::StreamExt;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
 
 #[cfg(test)]
-use ::axum_test::TestServer;
+use axum_test::TestServer;
 #[cfg(test)]
-use ::axum_test::TestServerConfig;
+use axum_test::TestServerConfig;
 
 const PORT: u16 = 8080;
 

--- a/examples/example-websocket-ping-pong/main.rs
+++ b/examples/example-websocket-ping-pong/main.rs
@@ -10,22 +10,22 @@
 //! ```
 //!
 
-use ::anyhow::Result;
-use ::axum::extract::ws::WebSocket;
-use ::axum::extract::WebSocketUpgrade;
-use ::axum::response::Response;
-use ::axum::routing::get;
-use ::axum::serve::serve;
-use ::axum::Router;
-use ::std::net::IpAddr;
-use ::std::net::Ipv4Addr;
-use ::std::net::SocketAddr;
-use ::tokio::net::TcpListener;
+use anyhow::Result;
+use axum::extract::ws::WebSocket;
+use axum::extract::WebSocketUpgrade;
+use axum::response::Response;
+use axum::routing::get;
+use axum::serve::serve;
+use axum::Router;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
 
 #[cfg(test)]
-use ::axum_test::TestServer;
+use axum_test::TestServer;
 #[cfg(test)]
-use ::axum_test::TestServerConfig;
+use axum_test::TestServerConfig;
 
 const PORT: u16 = 8080;
 
@@ -86,7 +86,7 @@ fn new_test_app() -> TestServer {
 mod test_websockets_ping_pong {
     use super::*;
 
-    use ::serde_json::json;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_start_a_websocket_connection() {

--- a/src/internals/query_params_store.rs
+++ b/src/internals/query_params_store.rs
@@ -1,9 +1,9 @@
-use ::anyhow::Result;
-use ::serde::Serialize;
-use ::smallvec::SmallVec;
-use ::std::fmt::Display;
-use ::std::fmt::Formatter;
-use ::std::fmt::Result as FmtResult;
+use anyhow::Result;
+use serde::Serialize;
+use smallvec::SmallVec;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct QueryParamsStore {

--- a/src/internals/request_path_formatter.rs
+++ b/src/internals/request_path_formatter.rs
@@ -1,5 +1,5 @@
-use ::http::Method;
-use ::std::fmt;
+use http::Method;
+use std::fmt;
 
 use crate::internals::QueryParamsStore;
 

--- a/src/internals/starting_tcp_setup.rs
+++ b/src/internals/starting_tcp_setup.rs
@@ -1,11 +1,11 @@
-use ::anyhow::Context;
-use ::anyhow::Result;
-use ::reserve_port::ReservedPort;
-use ::std::net::IpAddr;
-use ::std::net::Ipv4Addr;
-use ::std::net::SocketAddr;
-use ::std::net::TcpListener as StdTcpListener;
-use ::tokio::net::TcpListener as TokioTcpListener;
+use anyhow::Context;
+use anyhow::Result;
+use reserve_port::ReservedPort;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use std::net::TcpListener as StdTcpListener;
+use tokio::net::TcpListener as TokioTcpListener;
 
 pub const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
@@ -56,8 +56,8 @@ impl StartingTcpSetup {
 #[cfg(test)]
 mod test_new {
     use super::*;
-    use ::regex::Regex;
-    use ::std::net::Ipv4Addr;
+    use regex::Regex;
+    use std::net::Ipv4Addr;
 
     #[tokio::test]
     async fn it_should_create_default_ip_with_random_port_when_none() {

--- a/src/internals/status_code_formatter.rs
+++ b/src/internals/status_code_formatter.rs
@@ -1,5 +1,5 @@
-use ::http::StatusCode;
-use ::std::fmt;
+use http::StatusCode;
+use std::fmt;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct StatusCodeFormatter(pub StatusCode);

--- a/src/internals/transport_layer/http_transport_layer.rs
+++ b/src/internals/transport_layer/http_transport_layer.rs
@@ -1,12 +1,12 @@
-use ::anyhow::Result;
-use ::axum::body::Body;
-use ::http::Request;
-use ::http::Response;
-use ::hyper_util::client::legacy::Client;
-use ::reserve_port::ReservedPort;
-use ::std::future::Future;
-use ::std::pin::Pin;
-use ::url::Url;
+use anyhow::Result;
+use axum::body::Body;
+use http::Request;
+use http::Response;
+use hyper_util::client::legacy::Client;
+use reserve_port::ReservedPort;
+use std::future::Future;
+use std::pin::Pin;
+use url::Url;
 
 use crate::transport_layer::TransportLayer;
 use crate::transport_layer::TransportLayerType;

--- a/src/internals/transport_layer/mock_transport_layer.rs
+++ b/src/internals/transport_layer/mock_transport_layer.rs
@@ -1,15 +1,15 @@
-use ::anyhow::Error as AnyhowError;
-use ::anyhow::Result;
-use ::axum::body::Body;
-use ::axum::response::Response as AxumResponse;
-use ::bytes::Bytes;
-use ::http::Request;
-use ::http::Response;
-use ::std::fmt::Debug;
-use ::std::future::Future;
-use ::std::pin::Pin;
-use ::tower::util::ServiceExt;
-use ::tower::Service;
+use anyhow::Error as AnyhowError;
+use anyhow::Result;
+use axum::body::Body;
+use axum::response::Response as AxumResponse;
+use bytes::Bytes;
+use http::Request;
+use http::Response;
+use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
+use tower::util::ServiceExt;
+use tower::Service;
 
 use crate::transport_layer::TransportLayer;
 use crate::transport_layer::TransportLayerType;

--- a/src/internals/websockets/test_response_websocket.rs
+++ b/src/internals/websockets/test_response_websocket.rs
@@ -1,4 +1,4 @@
-use ::hyper::upgrade::OnUpgrade;
+use hyper::upgrade::OnUpgrade;
 
 use crate::transport_layer::TransportLayerType;
 

--- a/src/internals/websockets/ws_key_generator.rs
+++ b/src/internals/websockets/ws_key_generator.rs
@@ -1,6 +1,6 @@
-use ::base64::engine::general_purpose::STANDARD;
-use ::base64::Engine;
-use ::uuid::Uuid;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use uuid::Uuid;
 
 /// Generates a random key for use, that is base 64 encoded for use over HTTP.
 pub fn generate_ws_key() -> String {

--- a/src/internals/with_this_mut.rs
+++ b/src/internals/with_this_mut.rs
@@ -1,7 +1,7 @@
-use ::anyhow::anyhow;
-use ::anyhow::Result;
-use ::std::sync::Arc;
-use ::std::sync::Mutex;
+use anyhow::anyhow;
+use anyhow::Result;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 pub fn with_this_mut<T, F, R>(this: &Arc<Mutex<T>>, name: &str, some_action: F) -> Result<R>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,12 @@
 //! ```rust
 //! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 //! #
-//! use ::axum::Router;
-//! use ::axum::extract::Json;
-//! use ::axum::routing::put;
-//! use ::axum_test::TestServer;
-//! use ::serde_json::json;
-//! use ::serde_json::Value;
+//! use axum::Router;
+//! use axum::extract::Json;
+//! use axum::routing::put;
+//! use axum_test::TestServer;
+//! use serde_json::json;
+//! use serde_json::Value;
 //!
 //! async fn route_put_user(Json(user): Json<Value>) -> () {
 //!     // todo
@@ -44,12 +44,12 @@
 //! ```rust
 //! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 //! #
-//! # use ::axum::Router;
-//! # use ::axum::extract::Json;
-//! # use ::axum::routing::put;
-//! # use ::axum_test::TestServer;
-//! # use ::serde_json::json;
-//! # use ::serde_json::Value;
+//! # use axum::Router;
+//! # use axum::extract::Json;
+//! # use axum::routing::put;
+//! # use axum_test::TestServer;
+//! # use serde_json::json;
+//! # use serde_json::Value;
 //! #
 //! # async fn put_user(Json(user): Json<Value>) -> () {}
 //! #
@@ -93,9 +93,9 @@
 //! ```rust
 //! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 //! #
-//! use ::axum::Router;
-//! use ::axum_test::TestServer;
-//! use ::axum_test::TestServerConfig;
+//! use axum::Router;
+//! use axum_test::TestServer;
+//! use axum_test::TestServerConfig;
 //!
 //! let my_app = Router::new();
 //! let config = TestServerConfig::builder()
@@ -125,9 +125,9 @@
 //! ```rust
 //! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 //! #
-//! use ::axum::Router;
-//! use ::axum_test::TestServer;
-//! use ::axum_test::TestServerConfig;
+//! use axum::Router;
+//! use axum_test::TestServer;
+//! use axum_test::TestServerConfig;
 //!
 //! let my_app = Router::new();
 //! let config = TestServerConfig::builder()
@@ -151,12 +151,12 @@
 //! ```rust
 //! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 //! #
-//! use ::axum::Router;
-//! use ::axum::extract::Json;
-//! use ::axum::routing::put;
-//! use ::axum_test::TestServer;
-//! use ::serde_json::json;
-//! use ::serde_json::Value;
+//! use axum::Router;
+//! use axum::extract::Json;
+//! use axum::routing::put;
+//! use axum_test::TestServer;
+//! use serde_json::json;
+//! use serde_json::Value;
 //!
 //! async fn put_user(Json(user): Json<Value>) -> () {
 //!     // todo
@@ -218,28 +218,28 @@ mod test_web_socket;
 #[cfg(feature = "ws")]
 pub use self::test_web_socket::*;
 #[cfg(feature = "ws")]
-pub use ::tokio_tungstenite::tungstenite::Message as WsMessage;
+pub use tokio_tungstenite::tungstenite::Message as WsMessage;
 
 mod transport;
 pub use self::transport::*;
 
-pub use ::http;
+pub use http;
 
 #[cfg(test)]
 mod integrated_test_cookie_saving {
     use super::*;
 
-    use ::axum::extract::Request;
-    use ::axum::routing::get;
-    use ::axum::routing::post;
-    use ::axum::routing::put;
-    use ::axum::Router;
-    use ::axum_extra::extract::cookie::Cookie as AxumCookie;
-    use ::axum_extra::extract::cookie::CookieJar;
-    use ::cookie::time::OffsetDateTime;
-    use ::cookie::Cookie;
-    use ::http_body_util::BodyExt;
-    use ::std::time::Duration;
+    use axum::extract::Request;
+    use axum::routing::get;
+    use axum::routing::post;
+    use axum::routing::put;
+    use axum::Router;
+    use axum_extra::extract::cookie::Cookie as AxumCookie;
+    use axum_extra::extract::cookie::CookieJar;
+    use cookie::time::OffsetDateTime;
+    use cookie::Cookie;
+    use http_body_util::BodyExt;
+    use std::time::Duration;
 
     const TEST_COOKIE_NAME: &'static str = &"test-cookie";
 
@@ -458,12 +458,12 @@ mod integrated_test_cookie_saving {
 mod integrated_test_typed_routing_and_query {
     use super::*;
 
-    use ::axum::extract::Query;
-    use ::axum::Router;
-    use ::axum_extra::routing::RouterExt;
-    use ::axum_extra::routing::TypedPath;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use axum::extract::Query;
+    use axum::Router;
+    use axum_extra::routing::RouterExt;
+    use axum_extra::routing::TypedPath;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     #[derive(TypedPath, Deserialize)]
     #[typed_path("/path-query/:id")]

--- a/src/multipart/mod.rs
+++ b/src/multipart/mod.rs
@@ -9,9 +9,9 @@
 //! ```rust
 //! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 //! #
-//! use ::axum::Router;
-//! use ::axum_test::TestServer;
-//! use ::axum_test::multipart::MultipartForm;
+//! use axum::Router;
+//! use axum_test::TestServer;
+//! use axum_test::multipart::MultipartForm;
 //!
 //! let app = Router::new();
 //! let server = TestServer::new(app)?;
@@ -32,10 +32,10 @@
 //! ```rust
 //! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 //! #
-//! use ::axum::Router;
-//! use ::axum_test::TestServer;
-//! use ::axum_test::multipart::MultipartForm;
-//! use ::axum_test::multipart::Part;
+//! use axum::Router;
+//! use axum_test::TestServer;
+//! use axum_test::multipart::MultipartForm;
+//! use axum_test::multipart::Part;
 //!
 //! let app = Router::new();
 //! let server = TestServer::new(app)?;

--- a/src/multipart/multipart_form.rs
+++ b/src/multipart/multipart_form.rs
@@ -1,8 +1,8 @@
-use ::axum::body::Body as AxumBody;
-use ::rust_multipart_rfc7578_2::client::multipart::Body as CommonMultipartBody;
-use ::rust_multipart_rfc7578_2::client::multipart::Form;
-use ::std::fmt::Display;
-use ::std::io::Cursor;
+use axum::body::Body as AxumBody;
+use rust_multipart_rfc7578_2::client::multipart::Body as CommonMultipartBody;
+use rust_multipart_rfc7578_2::client::multipart::Form;
+use std::fmt::Display;
+use std::io::Cursor;
 
 use crate::multipart::Part;
 

--- a/src/multipart/part.rs
+++ b/src/multipart/part.rs
@@ -1,7 +1,7 @@
-use ::anyhow::Context;
-use ::bytes::Bytes;
-use ::mime::Mime;
-use ::std::fmt::Display;
+use anyhow::Context;
+use bytes::Bytes;
+use mime::Mime;
+use std::fmt::Display;
 
 ///
 /// For creating a section of a MultipartForm.

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -1,27 +1,27 @@
-use ::anyhow::anyhow;
-use ::anyhow::Context;
-use ::anyhow::Error as AnyhowError;
-use ::anyhow::Result;
-use ::auto_future::AutoFuture;
-use ::axum::body::Body;
-use ::bytes::Bytes;
-use ::cookie::time::OffsetDateTime;
-use ::cookie::Cookie;
-use ::cookie::CookieJar;
-use ::http::header;
-use ::http::header::SET_COOKIE;
-use ::http::HeaderName;
-use ::http::HeaderValue;
-use ::http::Method;
-use ::http::Request;
-use ::http_body_util::BodyExt;
-use ::serde::Serialize;
-use ::std::fmt::Debug;
-use ::std::fmt::Display;
-use ::std::future::IntoFuture;
-use ::std::sync::Arc;
-use ::std::sync::Mutex;
-use ::url::Url;
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Error as AnyhowError;
+use anyhow::Result;
+use auto_future::AutoFuture;
+use axum::body::Body;
+use bytes::Bytes;
+use cookie::time::OffsetDateTime;
+use cookie::Cookie;
+use cookie::CookieJar;
+use http::header;
+use http::header::SET_COOKIE;
+use http::HeaderName;
+use http::HeaderValue;
+use http::Method;
+use http::Request;
+use http_body_util::BodyExt;
+use serde::Serialize;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::future::IntoFuture;
+use std::sync::Arc;
+use std::sync::Mutex;
+use url::Url;
 
 use crate::internals::ExpectedState;
 use crate::internals::QueryParamsStore;
@@ -61,8 +61,8 @@ mod test_request_config;
 /// ```rust
 /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 /// #
-/// # use ::axum::Router;
-/// # use ::axum_test::TestServer;
+/// # use axum::Router;
+/// # use axum_test::TestServer;
 /// #
 /// # let server = TestServer::new(Router::new())?;
 /// #
@@ -196,9 +196,9 @@ impl TestRequest {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
-    /// use ::axum_test::multipart::MultipartForm;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
+    /// use axum_test::multipart::MultipartForm;
     ///
     /// let app = Router::new();
     /// let server = TestServer::new(app)?;
@@ -219,10 +219,10 @@ impl TestRequest {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
-    /// use ::axum_test::multipart::MultipartForm;
-    /// use ::axum_test::multipart::Part;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
+    /// use axum_test::multipart::MultipartForm;
+    /// use axum_test::multipart::Part;
     ///
     /// let app = Router::new();
     /// let server = TestServer::new(app)?;
@@ -334,9 +334,9 @@ impl TestRequest {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
-    /// use ::serde_json::json;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
+    /// use serde_json::json;
     ///
     /// let app = Router::new();
     /// let server = TestServer::new(app)?;
@@ -356,10 +356,10 @@ impl TestRequest {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
-    /// use ::serde::Deserialize;
-    /// use ::serde::Serialize;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
+    /// use serde::Deserialize;
+    /// use serde::Serialize;
     ///
     /// #[derive(Serialize, Deserialize)]
     /// struct UserQueryParams {
@@ -385,8 +385,8 @@ impl TestRequest {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
     ///
     /// let app = Router::new();
     /// let server = TestServer::new(app)?;
@@ -428,8 +428,8 @@ impl TestRequest {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
     ///
     /// let app = Router::new();
     /// let server = TestServer::new(app)?;
@@ -461,8 +461,8 @@ impl TestRequest {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
     ///
     /// let app = Router::new();
     /// let server = TestServer::new(app)?;
@@ -527,8 +527,8 @@ impl TestRequest {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
     ///
     /// let app = Router::new();
     /// let server = TestServer::new(app)?;
@@ -559,12 +559,12 @@ impl TestRequest {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Json;
-    /// use ::axum::routing::Router;
-    /// use ::axum::routing::put;
-    /// use ::serde_json::json;
+    /// use axum::Json;
+    /// use axum::routing::Router;
+    /// use axum::routing::put;
+    /// use serde_json::json;
     ///
-    /// use ::axum_test::TestServer;
+    /// use axum_test::TestServer;
     ///
     /// let app = Router::new()
     ///     .route(&"/todo", put(|| async { unimplemented!() }));
@@ -784,10 +784,10 @@ mod test_content_type {
     use crate::TestServer;
     use crate::TestServerConfig;
 
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::header::CONTENT_TYPE;
-    use ::http::HeaderMap;
+    use axum::routing::get;
+    use axum::Router;
+    use http::header::CONTENT_TYPE;
+    use http::HeaderMap;
 
     async fn get_content_type(headers: HeaderMap) -> String {
         headers
@@ -855,14 +855,14 @@ mod test_content_type {
 mod test_json {
     use crate::TestServer;
 
-    use ::axum::routing::post;
-    use ::axum::Json;
-    use ::axum::Router;
-    use ::http::header::CONTENT_TYPE;
-    use ::http::HeaderMap;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
-    use ::serde_json::json;
+    use axum::routing::post;
+    use axum::Json;
+    use axum::Router;
+    use http::header::CONTENT_TYPE;
+    use http::HeaderMap;
+    use serde::Deserialize;
+    use serde::Serialize;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_pass_json_up_to_be_read() {
@@ -929,14 +929,14 @@ mod test_json {
 mod test_yaml {
     use crate::TestServer;
 
-    use ::axum::routing::post;
-    use ::axum::Router;
-    use ::axum_yaml::Yaml;
-    use ::http::header::CONTENT_TYPE;
-    use ::http::HeaderMap;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
-    use ::serde_json::json;
+    use axum::routing::post;
+    use axum::Router;
+    use axum_yaml::Yaml;
+    use http::header::CONTENT_TYPE;
+    use http::HeaderMap;
+    use serde::Deserialize;
+    use serde::Serialize;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_pass_yaml_up_to_be_read() {
@@ -1003,14 +1003,14 @@ mod test_yaml {
 mod test_msgpack {
     use crate::TestServer;
 
-    use ::axum::routing::post;
-    use ::axum::Router;
-    use ::axum_msgpack::MsgPack;
-    use ::http::header::CONTENT_TYPE;
-    use ::http::HeaderMap;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
-    use ::serde_json::json;
+    use axum::routing::post;
+    use axum::Router;
+    use axum_msgpack::MsgPack;
+    use http::header::CONTENT_TYPE;
+    use http::HeaderMap;
+    use serde::Deserialize;
+    use serde::Serialize;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_pass_msgpack_up_to_be_read() {
@@ -1080,13 +1080,13 @@ mod test_msgpack {
 mod test_form {
     use crate::TestServer;
 
-    use ::axum::routing::post;
-    use ::axum::Form;
-    use ::axum::Router;
-    use ::http::header::CONTENT_TYPE;
-    use ::http::HeaderMap;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use axum::routing::post;
+    use axum::Form;
+    use axum::Router;
+    use http::header::CONTENT_TYPE;
+    use http::HeaderMap;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     #[tokio::test]
     async fn it_should_pass_form_up_to_be_read() {
@@ -1159,12 +1159,12 @@ mod test_form {
 mod test_text {
     use crate::TestServer;
 
-    use ::axum::extract::Request;
-    use ::axum::routing::post;
-    use ::axum::Router;
-    use ::http::header::CONTENT_TYPE;
-    use ::http::HeaderMap;
-    use ::http_body_util::BodyExt;
+    use axum::extract::Request;
+    use axum::routing::post;
+    use axum::Router;
+    use http::header::CONTENT_TYPE;
+    use http::HeaderMap;
+    use http_body_util::BodyExt;
 
     #[tokio::test]
     async fn it_should_pass_text_up_to_be_read() {
@@ -1217,9 +1217,9 @@ mod test_text {
 #[cfg(test)]
 mod test_expect_success {
     use crate::TestServer;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::StatusCode;
+    use axum::routing::get;
+    use axum::Router;
+    use http::StatusCode;
 
     #[tokio::test]
     async fn it_should_not_panic_if_success_is_returned() {
@@ -1287,9 +1287,9 @@ mod test_expect_success {
 #[cfg(test)]
 mod test_expect_failure {
     use crate::TestServer;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::StatusCode;
+    use axum::routing::get;
+    use axum::Router;
+    use http::StatusCode;
 
     #[tokio::test]
     async fn it_should_not_panic_if_expect_failure_on_404() {
@@ -1355,12 +1355,12 @@ mod test_expect_failure {
 mod test_add_cookie {
     use crate::TestServer;
 
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::axum_extra::extract::cookie::CookieJar;
-    use ::cookie::time::Duration;
-    use ::cookie::time::OffsetDateTime;
-    use ::cookie::Cookie;
+    use axum::routing::get;
+    use axum::Router;
+    use axum_extra::extract::cookie::CookieJar;
+    use cookie::time::Duration;
+    use cookie::time::OffsetDateTime;
+    use cookie::Cookie;
 
     const TEST_COOKIE_NAME: &'static str = &"test-cookie";
 
@@ -1414,13 +1414,13 @@ mod test_add_cookie {
 mod test_add_cookies {
     use crate::TestServer;
 
-    use ::axum::http::header::HeaderMap;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::axum_extra::extract::cookie::CookieJar as AxumCookieJar;
-    use ::cookie::Cookie;
-    use ::cookie::CookieJar;
-    use ::cookie::SameSite;
+    use axum::http::header::HeaderMap;
+    use axum::routing::get;
+    use axum::Router;
+    use axum_extra::extract::cookie::CookieJar as AxumCookieJar;
+    use cookie::Cookie;
+    use cookie::CookieJar;
+    use cookie::SameSite;
 
     async fn route_get_cookies(cookies: AxumCookieJar) -> String {
         let mut all_cookies = cookies
@@ -1492,15 +1492,15 @@ mod test_add_cookies {
 mod test_do_save_cookies {
     use crate::TestServer;
 
-    use ::axum::extract::Request;
-    use ::axum::http::header::HeaderMap;
-    use ::axum::routing::get;
-    use ::axum::routing::put;
-    use ::axum::Router;
-    use ::axum_extra::extract::cookie::CookieJar as AxumCookieJar;
-    use ::cookie::Cookie;
-    use ::cookie::SameSite;
-    use ::http_body_util::BodyExt;
+    use axum::extract::Request;
+    use axum::http::header::HeaderMap;
+    use axum::routing::get;
+    use axum::routing::put;
+    use axum::Router;
+    use axum_extra::extract::cookie::CookieJar as AxumCookieJar;
+    use cookie::Cookie;
+    use cookie::SameSite;
+    use http_body_util::BodyExt;
 
     const TEST_COOKIE_NAME: &'static str = &"test-cookie";
 
@@ -1563,15 +1563,15 @@ mod test_do_save_cookies {
 mod test_clear_cookies {
     use crate::TestServer;
 
-    use ::axum::extract::Request;
-    use ::axum::routing::get;
-    use ::axum::routing::put;
-    use ::axum::Router;
-    use ::axum_extra::extract::cookie::Cookie as AxumCookie;
-    use ::axum_extra::extract::cookie::CookieJar as AxumCookieJar;
-    use ::cookie::Cookie;
-    use ::cookie::CookieJar;
-    use ::http_body_util::BodyExt;
+    use axum::extract::Request;
+    use axum::routing::get;
+    use axum::routing::put;
+    use axum::Router;
+    use axum_extra::extract::cookie::Cookie as AxumCookie;
+    use axum_extra::extract::cookie::CookieJar as AxumCookieJar;
+    use cookie::Cookie;
+    use cookie::CookieJar;
+    use http_body_util::BodyExt;
 
     const TEST_COOKIE_NAME: &'static str = &"test-cookie";
 
@@ -1678,15 +1678,15 @@ mod test_clear_cookies {
 mod test_add_header {
     use super::*;
 
-    use ::axum::async_trait;
-    use ::axum::extract::FromRequestParts;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::request::Parts;
-    use ::http::HeaderName;
-    use ::http::HeaderValue;
-    use ::hyper::StatusCode;
-    use ::std::marker::Sync;
+    use axum::async_trait;
+    use axum::extract::FromRequestParts;
+    use axum::routing::get;
+    use axum::Router;
+    use http::request::Parts;
+    use http::HeaderName;
+    use http::HeaderValue;
+    use hyper::StatusCode;
+    use std::marker::Sync;
 
     use crate::TestServer;
 
@@ -1741,13 +1741,13 @@ mod test_add_header {
 mod test_authorization {
     use super::*;
 
-    use ::axum::async_trait;
-    use ::axum::extract::FromRequestParts;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::request::Parts;
-    use ::hyper::StatusCode;
-    use ::std::marker::Sync;
+    use axum::async_trait;
+    use axum::extract::FromRequestParts;
+    use axum::routing::get;
+    use axum::Router;
+    use http::request::Parts;
+    use hyper::StatusCode;
+    use std::marker::Sync;
 
     use crate::TestServer;
 
@@ -1803,13 +1803,13 @@ mod test_authorization {
 mod test_authorization_bearer {
     use super::*;
 
-    use ::axum::async_trait;
-    use ::axum::extract::FromRequestParts;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::request::Parts;
-    use ::hyper::StatusCode;
-    use ::std::marker::Sync;
+    use axum::async_trait;
+    use axum::extract::FromRequestParts;
+    use axum::routing::get;
+    use axum::Router;
+    use http::request::Parts;
+    use hyper::StatusCode;
+    use std::marker::Sync;
 
     use crate::TestServer;
 
@@ -1865,15 +1865,15 @@ mod test_authorization_bearer {
 mod test_clear_headers {
     use super::*;
 
-    use ::axum::async_trait;
-    use ::axum::extract::FromRequestParts;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::request::Parts;
-    use ::http::HeaderName;
-    use ::http::HeaderValue;
-    use ::hyper::StatusCode;
-    use ::std::marker::Sync;
+    use axum::async_trait;
+    use axum::extract::FromRequestParts;
+    use axum::routing::get;
+    use axum::Router;
+    use http::request::Parts;
+    use http::HeaderName;
+    use http::HeaderValue;
+    use hyper::StatusCode;
+    use std::marker::Sync;
 
     use crate::TestServer;
 
@@ -1948,13 +1948,13 @@ mod test_clear_headers {
 
 #[cfg(test)]
 mod test_add_query_params {
-    use ::axum::extract::Query as AxumStdQuery;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::Query as AxumStdQuery;
+    use axum::routing::get;
+    use axum::Router;
 
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
-    use ::serde_json::json;
+    use serde::Deserialize;
+    use serde::Serialize;
+    use serde_json::json;
 
     use crate::TestServer;
 
@@ -2057,13 +2057,13 @@ mod test_add_query_params {
 
 #[cfg(test)]
 mod test_add_raw_query_param {
-    use ::axum::extract::Query as AxumStdQuery;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::axum_extra::extract::Query as AxumExtraQuery;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
-    use ::std::fmt::Write;
+    use axum::extract::Query as AxumStdQuery;
+    use axum::routing::get;
+    use axum::Router;
+    use axum_extra::extract::Query as AxumExtraQuery;
+    use serde::Deserialize;
+    use serde::Serialize;
+    use std::fmt::Write;
 
     use crate::TestServer;
 
@@ -2151,12 +2151,12 @@ mod test_add_raw_query_param {
 
 #[cfg(test)]
 mod test_add_query_param {
-    use ::axum::extract::Query;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::Query;
+    use axum::routing::get;
+    use axum::Router;
 
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     use crate::TestServer;
 
@@ -2215,12 +2215,12 @@ mod test_add_query_param {
 
 #[cfg(test)]
 mod test_clear_query_params {
-    use ::axum::extract::Query;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::Query;
+    use axum::routing::get;
+    use axum::Router;
 
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     use crate::TestServer;
 
@@ -2285,9 +2285,9 @@ mod test_clear_query_params {
 
 #[cfg(test)]
 mod test_scheme {
-    use ::axum::extract::Request;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::Request;
+    use axum::routing::get;
+    use axum::Router;
 
     use crate::TestServer;
     use crate::TestServerConfig;
@@ -2352,10 +2352,10 @@ mod test_scheme {
 
 #[cfg(test)]
 mod test_multipart {
-    use ::axum::extract::Multipart;
-    use ::axum::routing::post;
-    use ::axum::Json;
-    use ::axum::Router;
+    use axum::extract::Multipart;
+    use axum::routing::post;
+    use axum::Json;
+    use axum::Router;
 
     use crate::multipart::MultipartForm;
     use crate::multipart::Part;

--- a/src/test_request/test_request_config.rs
+++ b/src/test_request/test_request_config.rs
@@ -1,8 +1,8 @@
-use ::cookie::CookieJar;
-use ::http::HeaderName;
-use ::http::HeaderValue;
-use ::http::Method;
-use ::url::Url;
+use cookie::CookieJar;
+use http::HeaderName;
+use http::HeaderValue;
+use http::Method;
+use url::Url;
 
 use crate::internals::ExpectedState;
 use crate::internals::QueryParamsStore;

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -1,22 +1,22 @@
-use ::anyhow::Context;
-use ::bytes::Bytes;
-use ::cookie::Cookie;
-use ::cookie::CookieJar;
-use ::http::header::HeaderName;
-use ::http::header::SET_COOKIE;
-use ::http::response::Parts;
-use ::http::HeaderMap;
-use ::http::HeaderValue;
-use ::http::Method;
-use ::http::StatusCode;
-use ::serde::de::DeserializeOwned;
-use ::std::convert::AsRef;
-use ::std::fmt::Debug;
-use ::std::fmt::Display;
-use ::url::Url;
+use anyhow::Context;
+use bytes::Bytes;
+use cookie::Cookie;
+use cookie::CookieJar;
+use http::header::HeaderName;
+use http::header::SET_COOKIE;
+use http::response::Parts;
+use http::HeaderMap;
+use http::HeaderValue;
+use http::Method;
+use http::StatusCode;
+use serde::de::DeserializeOwned;
+use std::convert::AsRef;
+use std::fmt::Debug;
+use std::fmt::Display;
+use url::Url;
 
 #[cfg(feature = "pretty-assertions")]
-use ::pretty_assertions::{assert_eq, assert_ne};
+use pretty_assertions::{assert_eq, assert_ne};
 
 use crate::internals::RequestPathFormatter;
 use crate::internals::StatusCodeFormatter;
@@ -34,13 +34,13 @@ use crate::TestWebSocket;
 /// ```rust
 /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 /// #
-/// use ::axum::Json;
-/// use ::axum::routing::Router;
-/// use ::axum::routing::get;
-/// use ::serde::Deserialize;
-/// use ::serde::Serialize;
+/// use axum::Json;
+/// use axum::routing::Router;
+/// use axum::routing::get;
+/// use serde::Deserialize;
+/// use serde::Serialize;
 ///
-/// use ::axum_test::TestServer;
+/// use axum_test::TestServer;
 ///
 /// let app = Router::new()
 ///     .route(&"/test", get(|| async { "hello!" }));
@@ -63,12 +63,12 @@ use crate::TestWebSocket;
 /// ```rust
 /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 /// #
-/// # use ::axum::Json;
-/// # use ::axum::routing::Router;
-/// # use ::axum::routing::get;
-/// # use ::serde::Deserialize;
-/// # use ::serde::Serialize;
-/// # use ::axum_test::TestServer;
+/// # use axum::Json;
+/// # use axum::routing::Router;
+/// # use axum::routing::get;
+/// # use serde::Deserialize;
+/// # use serde::Serialize;
+/// # use axum_test::TestServer;
 /// #
 /// # #[derive(Serialize, Deserialize, Debug)]
 /// # struct Todo {}
@@ -101,13 +101,13 @@ use crate::TestWebSocket;
 /// ```rust
 /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 /// #
-/// use ::axum::Json;
-/// use ::axum::routing::Router;
-/// use ::axum::routing::get;
-/// use ::serde::Deserialize;
-/// use ::serde::Serialize;
+/// use axum::Json;
+/// use axum::routing::Router;
+/// use axum::routing::get;
+/// use serde::Deserialize;
+/// use serde::Serialize;
 ///
-/// use ::axum_test::TestServer;
+/// use axum_test::TestServer;
 ///
 /// let app = Router::new()
 ///     .route(&"/test", get(|| async { "hello!" }));
@@ -166,13 +166,13 @@ impl TestResponse {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Json;
-    /// use ::axum::routing::Router;
-    /// use ::axum::routing::get;
-    /// use ::serde_json::json;
-    /// use ::serde_json::Value;
+    /// use axum::Json;
+    /// use axum::routing::Router;
+    /// use axum::routing::get;
+    /// use serde_json::json;
+    /// use serde_json::Value;
     ///
-    /// use ::axum_test::TestServer;
+    /// use axum_test::TestServer;
     ///
     /// async fn route_get_todo() -> Json<Value> {
     ///     Json(json!({
@@ -206,13 +206,13 @@ impl TestResponse {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Json;
-    /// use ::axum::routing::Router;
-    /// use ::axum::routing::get;
-    /// use ::serde::Deserialize;
-    /// use ::serde::Serialize;
+    /// use axum::Json;
+    /// use axum::routing::Router;
+    /// use axum::routing::get;
+    /// use serde::Deserialize;
+    /// use serde::Serialize;
     ///
-    /// use ::axum_test::TestServer;
+    /// use axum_test::TestServer;
     ///
     /// #[derive(Serialize, Deserialize, Debug)]
     /// struct Todo {
@@ -260,13 +260,13 @@ impl TestResponse {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::routing::Router;
-    /// use ::axum::routing::get;
-    /// use ::axum_yaml::Yaml;
-    /// use ::serde::Deserialize;
-    /// use ::serde::Serialize;
+    /// use axum::routing::Router;
+    /// use axum::routing::get;
+    /// use axum_yaml::Yaml;
+    /// use serde::Deserialize;
+    /// use serde::Serialize;
     ///
-    /// use ::axum_test::TestServer;
+    /// use axum_test::TestServer;
     ///
     /// #[derive(Serialize, Deserialize, Debug)]
     /// struct Todo {
@@ -315,13 +315,13 @@ impl TestResponse {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::routing::Router;
-    /// use ::axum::routing::get;
-    /// use ::axum_msgpack::MsgPack;
-    /// use ::serde::Deserialize;
-    /// use ::serde::Serialize;
+    /// use axum::routing::Router;
+    /// use axum::routing::get;
+    /// use axum_msgpack::MsgPack;
+    /// use serde::Deserialize;
+    /// use serde::Serialize;
     ///
-    /// use ::axum_test::TestServer;
+    /// use axum_test::TestServer;
     ///
     /// #[derive(Serialize, Deserialize, Debug)]
     /// struct Todo {
@@ -370,13 +370,13 @@ impl TestResponse {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Form;
-    /// use ::axum::routing::Router;
-    /// use ::axum::routing::get;
-    /// use ::serde::Deserialize;
-    /// use ::serde::Serialize;
+    /// use axum::Form;
+    /// use axum::routing::Router;
+    /// use axum::routing::get;
+    /// use serde::Deserialize;
+    /// use serde::Serialize;
     ///
-    /// use ::axum_test::TestServer;
+    /// use axum_test::TestServer;
     ///
     /// #[derive(Serialize, Deserialize, Debug)]
     /// struct Todo {
@@ -652,9 +652,9 @@ impl TestResponse {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
-    /// use ::axum_test::TestServerConfig;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
+    /// use axum_test::TestServerConfig;
     ///
     /// let app = Router::new();
     /// let config = TestServerConfig::builder().http_transport().build();
@@ -924,9 +924,9 @@ impl From<TestResponse> for Bytes {
 
 #[cfg(test)]
 mod test_assert_header {
-    use ::axum::http::HeaderMap;
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
+    use axum::http::HeaderMap;
+    use axum::routing::get;
+    use axum::routing::Router;
 
     use crate::TestServer;
 
@@ -977,9 +977,9 @@ mod test_assert_header {
 
 #[cfg(test)]
 mod test_assert_contains_header {
-    use ::axum::http::HeaderMap;
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
+    use axum::http::HeaderMap;
+    use axum::routing::get;
+    use axum::routing::Router;
 
     use crate::TestServer;
 
@@ -1017,9 +1017,9 @@ mod test_assert_contains_header {
 
 #[cfg(test)]
 mod test_assert_success {
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::http::StatusCode;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use http::StatusCode;
 
     use crate::TestServer;
 
@@ -1061,9 +1061,9 @@ mod test_assert_success {
 
 #[cfg(test)]
 mod test_assert_failure {
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::http::StatusCode;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use http::StatusCode;
 
     use crate::TestServer;
 
@@ -1103,9 +1103,9 @@ mod test_assert_failure {
 
 #[cfg(test)]
 mod test_assert_status {
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::http::StatusCode;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use http::StatusCode;
 
     use crate::TestServer;
 
@@ -1133,9 +1133,9 @@ mod test_assert_status {
 
 #[cfg(test)]
 mod test_assert_not_status {
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::http::StatusCode;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use http::StatusCode;
 
     use crate::TestServer;
 
@@ -1167,11 +1167,11 @@ mod test_assert_not_status {
 #[cfg(test)]
 mod test_into_bytes {
     use crate::TestServer;
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::axum::Json;
-    use ::serde_json::json;
-    use ::serde_json::Value;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use axum::Json;
+    use serde_json::json;
+    use serde_json::Value;
 
     async fn route_get_json() -> Json<Value> {
         Json(json!({
@@ -1195,11 +1195,11 @@ mod test_into_bytes {
 #[cfg(test)]
 mod test_json {
     use crate::TestServer;
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::axum::Json;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use axum::Json;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct ExampleResponse {
@@ -1236,11 +1236,11 @@ mod test_json {
 #[cfg(test)]
 mod test_yaml {
     use crate::TestServer;
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::axum_yaml::Yaml;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use axum_yaml::Yaml;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct ExampleResponse {
@@ -1277,11 +1277,11 @@ mod test_yaml {
 #[cfg(test)]
 mod test_msgpack {
     use crate::TestServer;
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::axum_msgpack::MsgPack;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use axum_msgpack::MsgPack;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct ExampleResponse {
@@ -1317,11 +1317,11 @@ mod test_msgpack {
 #[cfg(test)]
 mod test_form {
     use crate::TestServer;
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::axum::Form;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use axum::Form;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct ExampleResponse {
@@ -1358,8 +1358,8 @@ mod test_form {
 mod test_assert_text {
     use crate::TestServer;
 
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
+    use axum::routing::get;
+    use axum::routing::Router;
 
     fn new_test_server() -> TestServer {
         async fn route_get_text() -> &'static str {
@@ -1401,8 +1401,8 @@ mod test_assert_text {
 mod test_assert_text_contains {
     use crate::TestServer;
 
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
+    use axum::routing::get;
+    use axum::routing::Router;
 
     fn new_test_server() -> TestServer {
         async fn route_get_text() -> &'static str {
@@ -1446,12 +1446,12 @@ mod test_assert_text_contains {
 mod test_assert_json {
     use crate::TestServer;
 
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::axum::Form;
-    use ::axum::Json;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use axum::Form;
+    use axum::Json;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct ExampleResponse {
@@ -1517,12 +1517,12 @@ mod test_assert_json {
 mod test_assert_yaml {
     use crate::TestServer;
 
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::axum::Form;
-    use ::axum_yaml::Yaml;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use axum::Form;
+    use axum_yaml::Yaml;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct ExampleResponse {
@@ -1587,12 +1587,12 @@ mod test_assert_yaml {
 mod test_assert_form {
     use crate::TestServer;
 
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
-    use ::axum::Form;
-    use ::axum::Json;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use axum::routing::get;
+    use axum::routing::Router;
+    use axum::Form;
+    use axum::Json;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct ExampleResponse {
@@ -1656,8 +1656,8 @@ mod test_assert_form {
 #[cfg(test)]
 mod test_text {
     use crate::TestServer;
-    use ::axum::routing::get;
-    use ::axum::routing::Router;
+    use axum::routing::get;
+    use axum::routing::Router;
 
     #[tokio::test]
     async fn it_should_deserialize_into_text() {
@@ -1681,11 +1681,11 @@ mod test_into_websocket {
     use crate::TestServer;
     use crate::TestServerConfig;
 
-    use ::axum::extract::ws::WebSocket;
-    use ::axum::extract::WebSocketUpgrade;
-    use ::axum::response::Response;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::ws::WebSocket;
+    use axum::extract::WebSocketUpgrade;
+    use axum::response::Response;
+    use axum::routing::get;
+    use axum::Router;
 
     fn new_test_router() -> Router {
         pub async fn route_get_websocket(ws: WebSocketUpgrade) -> Response {

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -1,20 +1,20 @@
-use ::anyhow::anyhow;
-use ::anyhow::Context;
-use ::anyhow::Result;
-use ::cookie::Cookie;
-use ::cookie::CookieJar;
-use ::http::HeaderName;
-use ::http::HeaderValue;
-use ::http::Method;
-use ::http::Uri;
-use ::serde::Serialize;
-use ::std::fmt::Debug;
-use ::std::sync::Arc;
-use ::std::sync::Mutex;
-use ::url::Url;
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use cookie::Cookie;
+use cookie::CookieJar;
+use http::HeaderName;
+use http::HeaderValue;
+use http::Method;
+use http::Uri;
+use serde::Serialize;
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::sync::Mutex;
+use url::Url;
 
 #[cfg(feature = "typed-routing")]
-use ::axum_extra::routing::TypedPath;
+use axum_extra::routing::TypedPath;
 
 use crate::internals::ExpectedState;
 use crate::transport_layer::IntoTransportLayer;
@@ -44,13 +44,13 @@ const DEFAULT_URL_ADDRESS: &'static str = "http://localhost";
 /// ```rust
 /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 /// #
-/// use ::axum::Json;
-/// use ::axum::routing::Router;
-/// use ::axum::routing::get;
-/// use ::serde::Deserialize;
-/// use ::serde::Serialize;
+/// use axum::Json;
+/// use axum::routing::Router;
+/// use axum::routing::get;
+/// use serde::Deserialize;
+/// use serde::Serialize;
 ///
-/// use ::axum_test::TestServer;
+/// use axum_test::TestServer;
 ///
 /// let app = Router::new()
 ///     .route(&"/todo", get(|| async { "hello!" }));
@@ -198,9 +198,9 @@ impl TestServer {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
-    /// use ::axum_test::TestServerConfig;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
+    /// use axum_test::TestServerConfig;
     ///
     /// let app = Router::new();
     /// let config = TestServerConfig::builder().http_transport().build();
@@ -219,7 +219,7 @@ impl TestServer {
     ///
     #[cfg(feature = "ws")]
     pub fn get_websocket(&self, path: &str) -> TestRequest {
-        use ::http::header;
+        use http::header;
 
         self.get(path)
             .add_header(header::CONNECTION, "upgrade")
@@ -242,15 +242,15 @@ impl TestServer {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Json;
-    /// use ::axum::routing::Router;
-    /// use ::axum::routing::get;
-    /// use ::axum_extra::routing::RouterExt;
-    /// use ::axum_extra::routing::TypedPath;
-    /// use ::serde::Deserialize;
-    /// use ::serde::Serialize;
+    /// use axum::Json;
+    /// use axum::routing::Router;
+    /// use axum::routing::get;
+    /// use axum_extra::routing::RouterExt;
+    /// use axum_extra::routing::TypedPath;
+    /// use serde::Deserialize;
+    /// use serde::Serialize;
     ///
-    /// use ::axum_test::TestServer;
+    /// use axum_test::TestServer;
     ///
     /// #[derive(TypedPath, Deserialize)]
     /// #[typed_path("/users/:user_id")]
@@ -362,9 +362,9 @@ impl TestServer {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
-    /// use ::axum_test::TestServerConfig;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
+    /// use axum_test::TestServerConfig;
     ///
     /// let app = Router::new();
     /// let server = TestServerConfig::builder()
@@ -513,8 +513,8 @@ impl TestServer {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
     ///
     /// let app = Router::new();
     /// let mut server = TestServer::new(app)?;
@@ -562,8 +562,8 @@ impl TestServer {
     /// ```rust
     /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
     /// #
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServer;
+    /// use axum::Router;
+    /// use axum_test::TestServer;
     ///
     /// let app = Router::new();
     /// let mut server = TestServer::new(app)?;
@@ -920,9 +920,9 @@ mod test_build_url {
 
 #[cfg(test)]
 mod test_new {
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::std::net::SocketAddr;
+    use axum::routing::get;
+    use axum::Router;
+    use std::net::SocketAddr;
 
     use crate::TestServer;
 
@@ -949,9 +949,9 @@ mod test_new {
 mod test_get {
     use super::*;
 
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::reserve_port::ReservedSocketAddr;
+    use axum::routing::get;
+    use axum::Router;
+    use reserve_port::ReservedSocketAddr;
 
     async fn get_ping() -> &'static str {
         "pong!"
@@ -1104,10 +1104,10 @@ mod test_get {
 mod test_server_address {
     use super::*;
 
-    use ::axum::Router;
-    use ::local_ip_address::local_ip;
-    use ::regex::Regex;
-    use ::reserve_port::ReservedPort;
+    use axum::Router;
+    use local_ip_address::local_ip;
+    use regex::Regex;
+    use reserve_port::ReservedPort;
 
     #[tokio::test]
     async fn it_should_return_address_used_from_config() {
@@ -1159,10 +1159,10 @@ mod test_server_address {
 mod test_server_url {
     use super::*;
 
-    use ::axum::Router;
-    use ::local_ip_address::local_ip;
-    use ::regex::Regex;
-    use ::reserve_port::ReservedPort;
+    use axum::Router;
+    use local_ip_address::local_ip;
+    use regex::Regex;
+    use reserve_port::ReservedPort;
 
     #[tokio::test]
     async fn it_should_return_address_with_url_on_http_ip_port() {
@@ -1302,10 +1302,10 @@ mod test_server_url {
 mod test_add_cookie {
     use crate::TestServer;
 
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::axum_extra::extract::cookie::CookieJar;
-    use ::cookie::Cookie;
+    use axum::routing::get;
+    use axum::Router;
+    use axum_extra::extract::cookie::CookieJar;
+    use cookie::Cookie;
 
     const TEST_COOKIE_NAME: &'static str = &"test-cookie";
 
@@ -1335,11 +1335,11 @@ mod test_add_cookie {
 mod test_add_cookies {
     use crate::TestServer;
 
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::axum_extra::extract::cookie::CookieJar as AxumCookieJar;
-    use ::cookie::Cookie;
-    use ::cookie::CookieJar;
+    use axum::routing::get;
+    use axum::Router;
+    use axum_extra::extract::cookie::CookieJar as AxumCookieJar;
+    use cookie::Cookie;
+    use cookie::CookieJar;
 
     async fn route_get_cookies(cookies: AxumCookieJar) -> String {
         let mut all_cookies = cookies
@@ -1376,11 +1376,11 @@ mod test_add_cookies {
 mod test_clear_cookies {
     use crate::TestServer;
 
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::axum_extra::extract::cookie::CookieJar as AxumCookieJar;
-    use ::cookie::Cookie;
-    use ::cookie::CookieJar;
+    use axum::routing::get;
+    use axum::Router;
+    use axum_extra::extract::cookie::CookieJar as AxumCookieJar;
+    use cookie::Cookie;
+    use cookie::CookieJar;
 
     async fn route_get_cookies(cookies: AxumCookieJar) -> String {
         let mut all_cookies = cookies
@@ -1416,15 +1416,15 @@ mod test_clear_cookies {
 mod test_add_header {
     use super::*;
 
-    use ::axum::async_trait;
-    use ::axum::extract::FromRequestParts;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::request::Parts;
-    use ::http::HeaderName;
-    use ::http::HeaderValue;
-    use ::hyper::StatusCode;
-    use ::std::marker::Sync;
+    use axum::async_trait;
+    use axum::extract::FromRequestParts;
+    use axum::routing::get;
+    use axum::Router;
+    use http::request::Parts;
+    use http::HeaderName;
+    use http::HeaderValue;
+    use hyper::StatusCode;
+    use std::marker::Sync;
 
     use crate::TestServer;
 
@@ -1477,15 +1477,15 @@ mod test_add_header {
 mod test_clear_headers {
     use super::*;
 
-    use ::axum::async_trait;
-    use ::axum::extract::FromRequestParts;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::request::Parts;
-    use ::http::HeaderName;
-    use ::http::HeaderValue;
-    use ::hyper::StatusCode;
-    use ::std::marker::Sync;
+    use axum::async_trait;
+    use axum::extract::FromRequestParts;
+    use axum::routing::get;
+    use axum::Router;
+    use http::request::Parts;
+    use http::HeaderName;
+    use http::HeaderValue;
+    use hyper::StatusCode;
+    use std::marker::Sync;
 
     use crate::TestServer;
 
@@ -1538,13 +1538,13 @@ mod test_clear_headers {
 
 #[cfg(test)]
 mod test_add_query_params {
-    use ::axum::extract::Query;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::Query;
+    use axum::routing::get;
+    use axum::Router;
 
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
-    use ::serde_json::json;
+    use serde::Deserialize;
+    use serde::Serialize;
+    use serde_json::json;
 
     use crate::TestServer;
 
@@ -1641,12 +1641,12 @@ mod test_add_query_params {
 
 #[cfg(test)]
 mod test_add_query_param {
-    use ::axum::extract::Query;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::Query;
+    use axum::routing::get;
+    use axum::Router;
 
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     use crate::TestServer;
 
@@ -1716,13 +1716,13 @@ mod test_add_query_param {
 
 #[cfg(test)]
 mod test_add_raw_query_param {
-    use ::axum::extract::Query as AxumStdQuery;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::axum_extra::extract::Query as AxumExtraQuery;
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
-    use ::std::fmt::Write;
+    use axum::extract::Query as AxumStdQuery;
+    use axum::routing::get;
+    use axum::Router;
+    use axum_extra::extract::Query as AxumExtraQuery;
+    use serde::Deserialize;
+    use serde::Serialize;
+    use std::fmt::Write;
 
     use crate::TestServer;
 
@@ -1807,12 +1807,12 @@ mod test_add_raw_query_param {
 
 #[cfg(test)]
 mod test_clear_query_params {
-    use ::axum::extract::Query;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::Query;
+    use axum::routing::get;
+    use axum::Router;
 
-    use ::serde::Deserialize;
-    use ::serde::Serialize;
+    use serde::Deserialize;
+    use serde::Serialize;
 
     use crate::TestServer;
 
@@ -1879,8 +1879,8 @@ mod test_clear_query_params {
 mod test_expect_success_by_default {
     use super::*;
 
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::routing::get;
+    use axum::Router;
 
     #[tokio::test]
     async fn it_should_not_panic_by_default_if_accessing_404_route() {
@@ -1934,10 +1934,10 @@ mod test_expect_success_by_default {
 mod test_content_type {
     use super::*;
 
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::header::CONTENT_TYPE;
-    use ::http::HeaderMap;
+    use axum::routing::get;
+    use axum::Router;
+    use http::header::CONTENT_TYPE;
+    use http::HeaderMap;
 
     async fn get_content_type(headers: HeaderMap) -> String {
         headers
@@ -1968,9 +1968,9 @@ mod test_content_type {
 #[cfg(test)]
 mod test_expect_success {
     use crate::TestServer;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::StatusCode;
+    use axum::routing::get;
+    use axum::Router;
+    use http::StatusCode;
 
     #[tokio::test]
     async fn it_should_not_panic_if_success_is_returned() {
@@ -2024,9 +2024,9 @@ mod test_expect_success {
 #[cfg(test)]
 mod test_expect_failure {
     use crate::TestServer;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::http::StatusCode;
+    use axum::routing::get;
+    use axum::Router;
+    use http::StatusCode;
 
     #[tokio::test]
     async fn it_should_not_panic_if_expect_failure_on_404() {
@@ -2080,9 +2080,9 @@ mod test_expect_failure {
 
 #[cfg(test)]
 mod test_scheme {
-    use ::axum::extract::Request;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::Request;
+    use axum::routing::get;
+    use axum::Router;
 
     use crate::TestServer;
     use crate::TestServerConfig;
@@ -2120,9 +2120,9 @@ mod test_scheme {
 mod test_typed_get {
     use super::*;
 
-    use ::axum::Router;
-    use ::axum_extra::routing::RouterExt;
-    use ::serde::Deserialize;
+    use axum::Router;
+    use axum_extra::routing::RouterExt;
+    use serde::Deserialize;
 
     #[derive(TypedPath, Deserialize)]
     #[typed_path("/path/:id")]
@@ -2154,9 +2154,9 @@ mod test_typed_get {
 mod test_typed_post {
     use super::*;
 
-    use ::axum::Router;
-    use ::axum_extra::routing::RouterExt;
-    use ::serde::Deserialize;
+    use axum::Router;
+    use axum_extra::routing::RouterExt;
+    use serde::Deserialize;
 
     #[derive(TypedPath, Deserialize)]
     #[typed_path("/path/:id")]
@@ -2188,9 +2188,9 @@ mod test_typed_post {
 mod test_typed_patch {
     use super::*;
 
-    use ::axum::Router;
-    use ::axum_extra::routing::RouterExt;
-    use ::serde::Deserialize;
+    use axum::Router;
+    use axum_extra::routing::RouterExt;
+    use serde::Deserialize;
 
     #[derive(TypedPath, Deserialize)]
     #[typed_path("/path/:id")]
@@ -2222,9 +2222,9 @@ mod test_typed_patch {
 mod test_typed_put {
     use super::*;
 
-    use ::axum::Router;
-    use ::axum_extra::routing::RouterExt;
-    use ::serde::Deserialize;
+    use axum::Router;
+    use axum_extra::routing::RouterExt;
+    use serde::Deserialize;
 
     #[derive(TypedPath, Deserialize)]
     #[typed_path("/path/:id")]
@@ -2256,9 +2256,9 @@ mod test_typed_put {
 mod test_typed_delete {
     use super::*;
 
-    use ::axum::Router;
-    use ::axum_extra::routing::RouterExt;
-    use ::serde::Deserialize;
+    use axum::Router;
+    use axum_extra::routing::RouterExt;
+    use serde::Deserialize;
 
     #[derive(TypedPath, Deserialize)]
     #[typed_path("/path/:id")]
@@ -2290,9 +2290,9 @@ mod test_typed_delete {
 mod test_typed_method {
     use super::*;
 
-    use ::axum::Router;
-    use ::axum_extra::routing::RouterExt;
-    use ::serde::Deserialize;
+    use axum::Router;
+    use axum_extra::routing::RouterExt;
+    use serde::Deserialize;
 
     #[derive(TypedPath, Deserialize)]
     #[typed_path("/path/:id")]
@@ -2383,9 +2383,9 @@ mod test_typed_method {
 #[cfg(test)]
 mod test_sync {
     use super::*;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::std::cell::OnceCell;
+    use axum::routing::get;
+    use axum::Router;
+    use std::cell::OnceCell;
 
     #[tokio::test]
     async fn it_should_be_able_to_be_in_one_cell() {

--- a/src/test_server/server_shared_state.rs
+++ b/src/test_server/server_shared_state.rs
@@ -1,12 +1,12 @@
-use ::anyhow::Context;
-use ::anyhow::Result;
-use ::cookie::Cookie;
-use ::cookie::CookieJar;
-use ::http::HeaderName;
-use ::http::HeaderValue;
-use ::serde::Serialize;
-use ::std::sync::Arc;
-use ::std::sync::Mutex;
+use anyhow::Context;
+use anyhow::Result;
+use cookie::Cookie;
+use cookie::CookieJar;
+use http::HeaderName;
+use http::HeaderValue;
+use serde::Serialize;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 use crate::internals::with_this_mut;
 use crate::internals::QueryParamsStore;

--- a/src/test_server_config.rs
+++ b/src/test_server_config.rs
@@ -1,4 +1,4 @@
-use ::anyhow::Result;
+use anyhow::Result;
 
 use crate::transport_layer::IntoTransportLayer;
 use crate::TestServer;
@@ -10,7 +10,7 @@ use crate::Transport;
 /// It implements [`Default`] to ease building configurations:
 ///
 /// ```rust
-/// use ::axum_test::TestServerConfig;
+/// use axum_test::TestServerConfig;
 ///
 /// let config = TestServerConfig {
 ///     save_cookies: true,
@@ -23,9 +23,9 @@ use crate::Transport;
 /// ```rust
 /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 /// #
-/// use ::axum::Router;
-/// use ::axum_test::TestServer;
-/// use ::axum_test::TestServerConfig;
+/// use axum::Router;
+/// use axum_test::TestServer;
+/// use axum_test::TestServerConfig;
 ///
 /// let my_app = Router::new();
 ///
@@ -103,7 +103,7 @@ impl TestServerConfig {
     /// Creates a builder for making it simpler to creating configs.
     ///
     /// ```rust
-    /// use ::axum_test::TestServerConfig;
+    /// use axum_test::TestServerConfig;
     ///
     /// let config = TestServerConfig::builder()
     ///     .save_cookies()
@@ -117,8 +117,8 @@ impl TestServerConfig {
     /// This is shorthand for calling [`crate::TestServer::new_with_config`].
     ///
     /// ```rust
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServerConfig;
+    /// use axum::Router;
+    /// use axum_test::TestServerConfig;
     ///
     /// let app = Router::new();
     /// let config = TestServerConfig::builder()

--- a/src/test_server_config_builder.rs
+++ b/src/test_server_config_builder.rs
@@ -1,5 +1,5 @@
-use ::anyhow::Result;
-use ::std::net::IpAddr;
+use anyhow::Result;
+use std::net::IpAddr;
 
 use crate::transport_layer::IntoTransportLayer;
 use crate::TestServer;
@@ -11,7 +11,7 @@ use crate::Transport;
 /// For full documentation see there.
 ///
 /// ```rust
-/// use ::axum_test::TestServerConfig;
+/// use axum_test::TestServerConfig;
 ///
 /// let config = TestServerConfig::builder()
 ///     .save_cookies()
@@ -24,9 +24,9 @@ use crate::Transport;
 /// ```rust
 /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
 /// #
-/// use ::axum::Router;
-/// use ::axum_test::TestServer;
-/// use ::axum_test::TestServerConfig;
+/// use axum::Router;
+/// use axum_test::TestServer;
+/// use axum_test::TestServerConfig;
 ///
 /// let my_app = Router::new();
 /// let config = TestServerConfig::builder()
@@ -100,8 +100,8 @@ impl TestServerConfigBuilder {
     /// This is shorthand for calling [`crate::TestServer::new_with_config`].
     ///
     /// ```rust
-    /// use ::axum::Router;
-    /// use ::axum_test::TestServerConfig;
+    /// use axum::Router;
+    /// use axum_test::TestServerConfig;
     ///
     /// let app = Router::new();
     /// let server = TestServerConfig::builder()
@@ -128,7 +128,7 @@ impl Default for TestServerConfigBuilder {
 #[cfg(test)]
 mod test_build {
     use super::*;
-    use ::std::net::Ipv4Addr;
+    use std::net::Ipv4Addr;
 
     #[test]
     fn it_should_build_default_config_by_default() {

--- a/src/test_web_socket.rs
+++ b/src/test_web_socket.rs
@@ -1,22 +1,22 @@
-use ::anyhow::anyhow;
-use ::anyhow::Context;
-use ::anyhow::Result;
-use ::bytes::Bytes;
-use ::futures_util::sink::SinkExt;
-use ::futures_util::stream::StreamExt;
-use ::hyper::upgrade::Upgraded;
-use ::hyper_util::rt::TokioIo;
-use ::serde::de::DeserializeOwned;
-use ::serde::Serialize;
-use ::std::fmt::Debug;
-use ::std::fmt::Display;
-use ::tokio_tungstenite::tungstenite::protocol::Role;
-use ::tokio_tungstenite::WebSocketStream;
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use bytes::Bytes;
+use futures_util::sink::SinkExt;
+use futures_util::stream::StreamExt;
+use hyper::upgrade::Upgraded;
+use hyper_util::rt::TokioIo;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::fmt::Debug;
+use std::fmt::Display;
+use tokio_tungstenite::tungstenite::protocol::Role;
+use tokio_tungstenite::WebSocketStream;
 
 use crate::WsMessage;
 
 #[cfg(feature = "pretty-assertions")]
-use ::pretty_assertions::assert_eq;
+use pretty_assertions::assert_eq;
 
 pub struct TestWebSocket {
     stream: WebSocketStream<TokioIo<Upgraded>>,
@@ -243,12 +243,12 @@ mod test_assert_receive_text {
     use crate::TestServer;
     use crate::TestServerConfig;
 
-    use ::axum::extract::ws::Message;
-    use ::axum::extract::ws::WebSocket;
-    use ::axum::extract::WebSocketUpgrade;
-    use ::axum::response::Response;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::ws::Message;
+    use axum::extract::ws::WebSocket;
+    use axum::extract::WebSocketUpgrade;
+    use axum::response::Response;
+    use axum::routing::get;
+    use axum::Router;
 
     fn new_test_app() -> TestServer {
         pub async fn route_get_websocket_ping_pong(ws: WebSocketUpgrade) -> Response {
@@ -325,12 +325,12 @@ mod test_assert_receive_text_contains {
     use crate::TestServer;
     use crate::TestServerConfig;
 
-    use ::axum::extract::ws::Message;
-    use ::axum::extract::ws::WebSocket;
-    use ::axum::extract::WebSocketUpgrade;
-    use ::axum::response::Response;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::ws::Message;
+    use axum::extract::ws::WebSocket;
+    use axum::extract::WebSocketUpgrade;
+    use axum::response::Response;
+    use axum::routing::get;
+    use axum::Router;
 
     fn new_test_app() -> TestServer {
         pub async fn route_get_websocket_ping_pong(ws: WebSocketUpgrade) -> Response {
@@ -403,14 +403,14 @@ mod test_assert_receive_json {
     use crate::TestServer;
     use crate::TestServerConfig;
 
-    use ::axum::extract::ws::Message;
-    use ::axum::extract::ws::WebSocket;
-    use ::axum::extract::WebSocketUpgrade;
-    use ::axum::response::Response;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::serde_json::json;
-    use ::serde_json::Value;
+    use axum::extract::ws::Message;
+    use axum::extract::ws::WebSocket;
+    use axum::extract::WebSocketUpgrade;
+    use axum::response::Response;
+    use axum::routing::get;
+    use axum::Router;
+    use serde_json::json;
+    use serde_json::Value;
 
     fn new_test_app() -> TestServer {
         pub async fn route_get_websocket_ping_pong(ws: WebSocketUpgrade) -> Response {
@@ -491,14 +491,14 @@ mod test_assert_receive_yaml {
     use crate::TestServer;
     use crate::TestServerConfig;
 
-    use ::axum::extract::ws::Message;
-    use ::axum::extract::ws::WebSocket;
-    use ::axum::extract::WebSocketUpgrade;
-    use ::axum::response::Response;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::serde_json::json;
-    use ::serde_json::Value;
+    use axum::extract::ws::Message;
+    use axum::extract::ws::WebSocket;
+    use axum::extract::WebSocketUpgrade;
+    use axum::response::Response;
+    use axum::routing::get;
+    use axum::Router;
+    use serde_json::json;
+    use serde_json::Value;
 
     fn new_test_app() -> TestServer {
         pub async fn route_get_websocket_ping_pong(ws: WebSocketUpgrade) -> Response {
@@ -580,14 +580,14 @@ mod test_assert_receive_msgpack {
     use crate::TestServer;
     use crate::TestServerConfig;
 
-    use ::axum::extract::ws::Message;
-    use ::axum::extract::ws::WebSocket;
-    use ::axum::extract::WebSocketUpgrade;
-    use ::axum::response::Response;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::serde_json::json;
-    use ::serde_json::Value;
+    use axum::extract::ws::Message;
+    use axum::extract::ws::WebSocket;
+    use axum::extract::WebSocketUpgrade;
+    use axum::response::Response;
+    use axum::routing::get;
+    use axum::Router;
+    use serde_json::json;
+    use serde_json::Value;
 
     fn new_test_app() -> TestServer {
         pub async fn route_get_websocket_ping_pong(ws: WebSocketUpgrade) -> Response {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,4 +1,4 @@
-use ::std::net::IpAddr;
+use std::net::IpAddr;
 
 /// Transport is for setting which transport mode for the `TestServer`
 /// to use when making requests.

--- a/src/transport_layer/into_transport_layer.rs
+++ b/src/transport_layer/into_transport_layer.rs
@@ -1,4 +1,4 @@
-use ::anyhow::Result;
+use anyhow::Result;
 
 use crate::transport_layer::TransportLayer;
 use crate::transport_layer::TransportLayerBuilder;

--- a/src/transport_layer/into_transport_layer/axum_service.rs
+++ b/src/transport_layer/into_transport_layer/axum_service.rs
@@ -1,6 +1,6 @@
-use ::anyhow::Result;
-use ::axum::Router;
-use ::shuttle_axum::AxumService;
+use anyhow::Result;
+use axum::Router;
+use shuttle_axum::AxumService;
 
 use crate::transport_layer::IntoTransportLayer;
 use crate::transport_layer::TransportLayer;
@@ -23,9 +23,9 @@ impl IntoTransportLayer for AxumService {
 mod test_into_http_transport_layer_for_axum_service {
     use super::*;
 
-    use ::axum::extract::State;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::State;
+    use axum::routing::get;
+    use axum::Router;
 
     use crate::TestServerConfig;
 
@@ -56,9 +56,9 @@ mod test_into_http_transport_layer_for_axum_service {
 mod test_into_mock_transport_layer_for_axum_service {
     use super::*;
 
-    use ::axum::extract::State;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::State;
+    use axum::routing::get;
+    use axum::Router;
 
     use crate::TestServerConfig;
 

--- a/src/transport_layer/into_transport_layer/into_make_service.rs
+++ b/src/transport_layer/into_transport_layer/into_make_service.rs
@@ -1,10 +1,10 @@
-use ::anyhow::Result;
-use ::axum::extract::Request as AxumRequest;
-use ::axum::response::Response as AxumResponse;
-use ::axum::routing::IntoMakeService;
-use ::std::convert::Infallible;
-use ::tower::Service;
-use ::url::Url;
+use anyhow::Result;
+use axum::extract::Request as AxumRequest;
+use axum::response::Response as AxumResponse;
+use axum::routing::IntoMakeService;
+use std::convert::Infallible;
+use tower::Service;
+use url::Url;
 
 use crate::internals::HttpTransportLayer;
 use crate::internals::MockTransportLayer;
@@ -45,13 +45,13 @@ where
 #[cfg(test)]
 mod test_into_http_transport_layer_for_into_make_service {
     use crate::TestServerConfig;
-    use ::axum::extract::Request;
-    use ::axum::extract::State;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::axum::ServiceExt;
-    use ::tower::Layer;
-    use ::tower_http::normalize_path::NormalizePathLayer;
+    use axum::extract::Request;
+    use axum::extract::State;
+    use axum::routing::get;
+    use axum::Router;
+    use axum::ServiceExt;
+    use tower::Layer;
+    use tower_http::normalize_path::NormalizePathLayer;
 
     async fn get_ping() -> &'static str {
         "pong!"
@@ -119,14 +119,14 @@ mod test_into_http_transport_layer_for_into_make_service {
 #[cfg(test)]
 mod test_into_mock_transport_layer_for_into_make_service {
     use crate::TestServerConfig;
-    use ::axum::extract::Request;
-    use ::axum::extract::State;
-    use ::axum::routing::get;
-    use ::axum::routing::IntoMakeService;
-    use ::axum::Router;
-    use ::axum::ServiceExt;
-    use ::tower::Layer;
-    use ::tower_http::normalize_path::NormalizePathLayer;
+    use axum::extract::Request;
+    use axum::extract::State;
+    use axum::routing::get;
+    use axum::routing::IntoMakeService;
+    use axum::Router;
+    use axum::ServiceExt;
+    use tower::Layer;
+    use tower_http::normalize_path::NormalizePathLayer;
 
     async fn get_ping() -> &'static str {
         "pong!"

--- a/src/transport_layer/into_transport_layer/into_make_service_with_connect_info.rs
+++ b/src/transport_layer/into_transport_layer/into_make_service_with_connect_info.rs
@@ -1,12 +1,12 @@
-use ::anyhow::anyhow;
-use ::anyhow::Result;
-use ::axum::extract::connect_info::IntoMakeServiceWithConnectInfo;
-use ::axum::extract::Request as AxumRequest;
-use ::axum::response::Response as AxumResponse;
-use ::axum::serve::IncomingStream;
-use ::std::convert::Infallible;
-use ::tower::Service;
-use ::url::Url;
+use anyhow::anyhow;
+use anyhow::Result;
+use axum::extract::connect_info::IntoMakeServiceWithConnectInfo;
+use axum::extract::Request as AxumRequest;
+use axum::response::Response as AxumResponse;
+use axum::serve::IncomingStream;
+use std::convert::Infallible;
+use tower::Service;
+use url::Url;
 
 use crate::internals::HttpTransportLayer;
 use crate::transport_layer::IntoTransportLayer;
@@ -53,13 +53,13 @@ where
 #[cfg(test)]
 mod test_into_http_transport_layer_for_into_make_service_with_connect_info {
     use crate::TestServerConfig;
-    use ::axum::extract::Request;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::axum::ServiceExt;
-    use ::std::net::SocketAddr;
-    use ::tower::Layer;
-    use ::tower_http::normalize_path::NormalizePathLayer;
+    use axum::extract::Request;
+    use axum::routing::get;
+    use axum::Router;
+    use axum::ServiceExt;
+    use std::net::SocketAddr;
+    use tower::Layer;
+    use tower_http::normalize_path::NormalizePathLayer;
 
     async fn get_ping() -> &'static str {
         "pong!"
@@ -104,9 +104,9 @@ mod test_into_http_transport_layer_for_into_make_service_with_connect_info {
 
 #[cfg(test)]
 mod test_into_mock_transport_layer_for_into_make_service_with_connect_info {
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::std::net::SocketAddr;
+    use axum::routing::get;
+    use axum::Router;
+    use std::net::SocketAddr;
 
     use crate::TestServerConfig;
 

--- a/src/transport_layer/into_transport_layer/router.rs
+++ b/src/transport_layer/into_transport_layer/router.rs
@@ -1,5 +1,5 @@
-use ::anyhow::Result;
-use ::axum::Router;
+use anyhow::Result;
+use axum::Router;
 
 use crate::transport_layer::IntoTransportLayer;
 use crate::transport_layer::TransportLayer;
@@ -20,9 +20,9 @@ impl IntoTransportLayer for Router<()> {
 
 #[cfg(test)]
 mod test_into_http_transport_layer {
-    use ::axum::extract::State;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::State;
+    use axum::routing::get;
+    use axum::Router;
 
     use crate::TestServerConfig;
 
@@ -69,9 +69,9 @@ mod test_into_http_transport_layer {
 
 #[cfg(test)]
 mod test_into_mock_transport_layer_for_router {
-    use ::axum::extract::State;
-    use ::axum::routing::get;
-    use ::axum::Router;
+    use axum::extract::State;
+    use axum::routing::get;
+    use axum::Router;
 
     use crate::TestServerConfig;
 

--- a/src/transport_layer/into_transport_layer/shuttle_axum.rs
+++ b/src/transport_layer/into_transport_layer/shuttle_axum.rs
@@ -1,5 +1,5 @@
-use ::anyhow::Result;
-use ::shuttle_axum::ShuttleAxum;
+use anyhow::Result;
+use shuttle_axum::ShuttleAxum;
 
 use crate::transport_layer::IntoTransportLayer;
 use crate::transport_layer::TransportLayer;
@@ -24,10 +24,10 @@ impl IntoTransportLayer for ShuttleAxum {
 mod test_into_http_transport_layer_for_shuttle_axum {
     use super::*;
 
-    use ::axum::extract::State;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::shuttle_axum::AxumService;
+    use axum::extract::State;
+    use axum::routing::get;
+    use axum::Router;
+    use shuttle_axum::AxumService;
 
     use crate::TestServerConfig;
 
@@ -58,10 +58,10 @@ mod test_into_http_transport_layer_for_shuttle_axum {
 mod test_into_mock_transport_layer_for_shuttle_axum {
     use super::*;
 
-    use ::axum::extract::State;
-    use ::axum::routing::get;
-    use ::axum::Router;
-    use ::shuttle_axum::AxumService;
+    use axum::extract::State;
+    use axum::routing::get;
+    use axum::Router;
+    use shuttle_axum::AxumService;
 
     use crate::TestServerConfig;
 

--- a/src/transport_layer/transport_layer.rs
+++ b/src/transport_layer/transport_layer.rs
@@ -1,11 +1,11 @@
-use ::anyhow::Result;
-use ::axum::body::Body;
-use ::http::Request;
-use ::http::Response;
-use ::std::fmt::Debug;
-use ::std::future::Future;
-use ::std::pin::Pin;
-use ::url::Url;
+use anyhow::Result;
+use axum::body::Body;
+use http::Request;
+use http::Response;
+use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
+use url::Url;
 
 use crate::transport_layer::TransportLayerType;
 

--- a/src/transport_layer/transport_layer_builder.rs
+++ b/src/transport_layer/transport_layer_builder.rs
@@ -1,9 +1,9 @@
-use ::anyhow::Context;
-use ::anyhow::Result;
-use ::reserve_port::ReservedPort;
-use ::std::net::IpAddr;
-use ::std::net::SocketAddr;
-use ::tokio::net::TcpListener;
+use anyhow::Context;
+use anyhow::Result;
+use reserve_port::ReservedPort;
+use std::net::IpAddr;
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
 
 use crate::internals::StartingTcpSetup;
 

--- a/src/util/new_random_port.rs
+++ b/src/util/new_random_port.rs
@@ -1,6 +1,6 @@
-use ::anyhow::anyhow;
-use ::anyhow::Result;
-use ::reserve_port::ReservedPort;
+use anyhow::anyhow;
+use anyhow::Result;
+use reserve_port::ReservedPort;
 
 /// Returns a randomly selected port that is not in use.
 pub fn new_random_port() -> Result<u16> {

--- a/src/util/new_random_socket_addr.rs
+++ b/src/util/new_random_socket_addr.rs
@@ -1,7 +1,7 @@
-use ::anyhow::Result;
-use ::std::net::IpAddr;
-use ::std::net::Ipv4Addr;
-use ::std::net::SocketAddr;
+use anyhow::Result;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
 
 use crate::util::new_random_port;
 

--- a/src/util/new_random_tcp_listener.rs
+++ b/src/util/new_random_tcp_listener.rs
@@ -1,9 +1,9 @@
-use ::anyhow::Result;
-use ::reserve_port::ReservedPort;
-use ::std::net::IpAddr;
-use ::std::net::Ipv4Addr;
-use ::std::net::SocketAddr;
-use ::std::net::TcpListener;
+use anyhow::Result;
+use reserve_port::ReservedPort;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use std::net::TcpListener;
 
 pub(crate) const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 

--- a/src/util/new_random_tokio_tcp_listener.rs
+++ b/src/util/new_random_tokio_tcp_listener.rs
@@ -1,9 +1,9 @@
-use ::anyhow::Result;
-use ::reserve_port::ReservedPort;
-use ::std::net::IpAddr;
-use ::std::net::Ipv4Addr;
-use ::std::net::SocketAddr;
-use ::tokio::net::TcpListener as TokioTcpListener;
+use anyhow::Result;
+use reserve_port::ReservedPort;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use tokio::net::TcpListener as TokioTcpListener;
 
 pub(crate) const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 

--- a/src/util/serve_handle.rs
+++ b/src/util/serve_handle.rs
@@ -1,4 +1,4 @@
-use ::tokio::task::JoinHandle;
+use tokio::task::JoinHandle;
 
 /// A handle to a running Axum service.
 ///

--- a/src/util/spawn_serve.rs
+++ b/src/util/spawn_serve.rs
@@ -1,11 +1,11 @@
-use ::axum::extract::Request;
-use ::axum::response::Response;
-use ::axum::serve;
-use ::axum::serve::IncomingStream;
-use ::std::convert::Infallible;
-use ::tokio::net::TcpListener;
-use ::tokio::spawn;
-use ::tower::Service;
+use axum::extract::Request;
+use axum::response::Response;
+use axum::serve;
+use axum::serve::IncomingStream;
+use std::convert::Infallible;
+use tokio::net::TcpListener;
+use tokio::spawn;
+use tower::Service;
 
 use crate::util::ServeHandle;
 


### PR DESCRIPTION
# Changes

 * Change absolute imports to relative ones.

# Comments

It makes sense to drop the absolute syntax given it's rarely used by other Rust developers.
This should make the code more idiomatic.
