### PR TITLE
fix: add std::marker::Sync trait in TransportLayer

### DIFF
--- a/src/internals/transport_layer/mock_transport_layer.rs
+++ b/src/internals/transport_layer/mock_transport_layer.rs
@@ -20,7 +20,7 @@ pub struct MockTransportLayer<S> {
 
 impl<S, RouterService> MockTransportLayer<S>
 where
-    S: Service<Request<Body>, Response = RouterService> + Clone + Send,
+    S: Service<Request<Body>, Response = RouterService> + Clone + Send + Sync,
     AnyhowError: From<S::Error>,
     S::Future: Send,
     RouterService: Service<Request<Body>, Response = AxumResponse>,
@@ -32,9 +32,9 @@ where
 
 impl<S, RouterService> TransportLayer for MockTransportLayer<S>
 where
-    S: Service<Request<Body>, Response = RouterService> + Clone + Send,
+    S: Service<Request<Body>, Response = RouterService> + Clone + Send + std::marker::Sync,
     AnyhowError: From<S::Error>,
-    S::Future: Send,
+    S::Future: Send + std::marker::Sync,
     RouterService: Service<Request<Body>, Response = AxumResponse>,
     AnyhowError: From<RouterService::Error>,
 {

--- a/src/transport_layer/into_transport_layer/into_make_service.rs
+++ b/src/transport_layer/into_transport_layer/into_make_service.rs
@@ -15,7 +15,11 @@ use crate::util::spawn_serve;
 
 impl<S> IntoTransportLayer for IntoMakeService<S>
 where
-    S: Service<AxumRequest, Response = AxumResponse, Error = Infallible> + Clone + Send + 'static,
+    S: Service<AxumRequest, Response = AxumResponse, Error = Infallible>
+        + Clone
+        + Send
+        + 'static
+        + std::marker::Sync,
     S::Future: Send,
 {
     fn into_http_transport_layer(

--- a/src/transport_layer/transport_layer.rs
+++ b/src/transport_layer/transport_layer.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::transport_layer::TransportLayerType;
 
-pub trait TransportLayer: Debug + Send {
+pub trait TransportLayer: Debug + Send + std::marker::Sync {
     fn send<'a>(
         &'a self,
         request: Request<Body>,


### PR DESCRIPTION
when using TestServer in tokio::sync::OnceCell Sync trait is required. in last version it was removed for some reasons which was a breaking change.

