### PR TITLE
Axum 0.8.1 upgrade, initial attempt to fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ reqwest = ["dep:reqwest"]
 [dependencies]
 auto-future = "1.0"
 assert-json-diff = "2.0"
-axum = { version = "0.7.9", features = [] }
+axum = { version = "0.8.1", features = [] }
 anyhow = "1.0"
 bytes = "1.8"
 bytesize = "1.3.0"

--- a/src/transport_layer/into_transport_layer/serve.rs
+++ b/src/transport_layer/into_transport_layer/serve.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use axum::extract::Request;
 use axum::response::Response;
 use axum::serve::IncomingStream;
+use axum::serve::Listener;
 use axum::serve::Serve;
 use std::convert::Infallible;
 use tokio::spawn;
@@ -16,10 +17,10 @@ use crate::transport_layer::TransportLayer;
 use crate::transport_layer::TransportLayerBuilder;
 use crate::util::ServeHandle;
 
-impl<M, S> IntoTransportLayer for Serve<M, S>
+impl<L, M, S> IntoTransportLayer for Serve<L, M, S>
 where
-    M: for<'a> Service<IncomingStream<'a>, Error = Infallible, Response = S> + Send + 'static,
-    for<'a> <M as Service<IncomingStream<'a>>>::Future: Send,
+    L: Listener,
+    M: for<'a> Service<IncomingStream<'a, L>, Error = Infallible, Response = S>,
     S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
     S::Future: Send,
 {

--- a/src/util/spawn_serve.rs
+++ b/src/util/spawn_serve.rs
@@ -16,8 +16,8 @@ use crate::util::ServeHandle;
 /// to terminate the service when dropped.
 pub fn spawn_serve<M, S>(tcp_listener: TcpListener, make_service: M) -> ServeHandle
 where
-    M: for<'a> Service<IncomingStream<'a>, Error = Infallible, Response = S> + Send + 'static,
-    for<'a> <M as Service<IncomingStream<'a>>>::Future: Send,
+    M: for<'a> Service<IncomingStream<'a, TcpListener>, Error = Infallible, Response = S> + Send + 'static,
+    for<'a> <M as Service<IncomingStream<'a, TcpListener>>>::Future: Send,
     S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
     S::Future: Send,
 {


### PR DESCRIPTION
I tried to take a look at Issue #129 and what could be needed to solve it. I hope this draft PR can at least point anyone with the proper knowledge of the libraries towards the necessary modifications.

Basically, by taking a look at the differences between axum `Serve` struct in [version 0.7.9](https://github.com/tokio-rs/axum/blob/9983bc1da460becd3a0f08c513d610411e84dd43/axum/src/serve.rs#L117) and in the [actual most recent version](https://github.com/tokio-rs/axum/blob/e0b55d750390d810028caad0387058751611c1b4/axum/src/serve.rs#L115) one can see that the `Serve` struct now is generic also on the `Listener` trait, evolving from

```rust
impl<M, S> Serve<M, S> {
```

to

```rust
impl<L, M, S> Serve<L, M, S>
where
    L: Listener,
{
```

So now I think the necessity for axum-test to work with axum version 0.8.1 is to adapt all its traits to be compatible with the new `Serve` struct.

I hope this "starting point" can be of any utility. Thank you very much for all the effort put into the library.