### PR TITLE
docs: remove shuttle reference on readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "17.0.0"
+version = "17.0.1"
 rust-version = "1.75"
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Here is a list of compatability with prior versions:
 You can find examples of writing tests in the [/examples folder](/examples/).
 These include tests for:
 
- * [a simple REST Todo application](/examples/example-todo), and [the same using Shuttle](/examples/example-shuttle)
+ * [a simple REST Todo application](/examples/example-todo)
  * [a WebSocket ping pong application](/examples/example-websocket-ping-pong) which sends requests up and down
  * [a simple WebSocket chat application](/examples/example-websocket-chat)
 


### PR DESCRIPTION
# Changes

 * Remove a mention to Shuttle from the Readme.
