### PR TITLE
feat: add multipart::Part::add_header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
 version = "17.2.0"
-rust-version = "1.80"
+rust-version = "1.83"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"
@@ -57,7 +57,7 @@ http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["client", "http1", "client-legacy"] }
 hyper = { version = "1.6", features = ["http1"] }
 mime = "0.3"
-rust-multipart-rfc7578_2 = "0.7"
+rust-multipart-rfc7578_2 = "0.8"
 reserve-port = "2.2"
 serde = { version = "1.0" }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "17.2.0"
+version = "17.3.0"
 rust-version = "1.83"
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
 version = "17.2.0"
-rust-version = "1.78"
+rust-version = "1.80"
 edition = "2021"
 license = "MIT"
 description = "For spinning up and testing Axum servers"
@@ -47,18 +47,18 @@ reqwest = ["dep:reqwest"]
 [dependencies]
 auto-future = "1.0"
 assert-json-diff = "2.0"
-axum = { version = "0.8.1", features = [] }
+axum = { version = "0.8.3", features = [] }
 anyhow = "1.0"
-bytes = "1.9"
-bytesize = "1.3.0"
+bytes = "1.10"
+bytesize = "2.0"
 cookie = "0.18"
-http = "1.2"
+http = "1.3"
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["client", "http1", "client-legacy"] }
-hyper = { version = "1.5", features = ["http1"] }
+hyper = { version = "1.6", features = ["http1"] }
 mime = "0.3"
 rust-multipart-rfc7578_2 = "0.7"
-reserve-port = "2.1"
+reserve-port = "2.2"
 serde = { version = "1.0" }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
@@ -74,7 +74,7 @@ pretty_assertions = { version = "1.4", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 # Shuttle
-shuttle-axum = { version = "0.51", optional = true }
+shuttle-axum = { version = "0.53", optional = true }
 
 # MsgPack
 rmp-serde = { version = "1.3", optional = true }
@@ -101,7 +101,7 @@ local-ip-address = "0.6"
 rand = { version = "0.9", features = ["small_rng"] }
 regex = "1.11"
 serde-email = { version = "3.1", features = ["serde"] }
-shuttle-axum = "0.51"
-shuttle-runtime = "0.51"
+shuttle-axum = "0.53"
+shuttle-runtime = "0.53"
 tokio = { version = "1.43", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
 tower-http = { version = "0.6", features = ["normalize-path"] }

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Here is a list of compatability with prior versions:
 
 | Axum Version    | Axum Test Version |
 |-----------------|-------------------|
-| 0.8.3+ (latest) | 17.2+ (latest)    |
+| 0.8.3+ (latest) | 17.3+ (latest)    |
 | 0.8.0           | 17                |
 | 0.7.6 to 0.7.9  | 16                |
 | 0.7.0 to 0.7.5  | 14, 15            |

--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ In both cases allowing you to run multiple servers, across multiple tests, all i
 
 ## Axum Compatability
 
-The current version of Axum Test requires at least Axum v0.7.6.
+The current version of Axum Test requires at least Axum v0.8.3.
 
 Here is a list of compatability with prior versions:
 
 | Axum Version    | Axum Test Version |
 |-----------------|-------------------|
-| 0.8.0+ (latest) | 17+ (latest)      |
+| 0.8.3+ (latest) | 17.2+ (latest)    |
+| 0.8.0           | 17                |
 | 0.7.6 to 0.7.9  | 16                |
 | 0.7.0 to 0.7.5  | 14, 15            |
 | 0.6             | 13.4.1            |

--- a/src/internals/debug_response_body.rs
+++ b/src/internals/debug_response_body.rs
@@ -7,6 +7,7 @@ use std::fmt::Result as FmtResult;
 /// An arbituary limit to avoid printing gigabytes to the terminal.
 const MAX_TEXT_PRINT_LEN: usize = 10_000;
 
+#[derive(Debug)]
 pub struct DebugResponseBody<'a>(pub &'a TestResponse);
 
 impl Display for DebugResponseBody<'_> {

--- a/src/internals/query_params_store.rs
+++ b/src/internals/query_params_store.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct QueryParamsStore {
     query_params: SmallVec<[String; 0]>,
 }

--- a/src/internals/starting_tcp_setup.rs
+++ b/src/internals/starting_tcp_setup.rs
@@ -9,6 +9,7 @@ use tokio::net::TcpListener as TokioTcpListener;
 
 pub const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
+#[derive(Debug)]
 pub struct StartingTcpSetup {
     pub maybe_reserved_port: Option<ReservedPort>,
     pub socket_addr: SocketAddr,

--- a/src/internals/websockets/test_response_websocket.rs
+++ b/src/internals/websockets/test_response_websocket.rs
@@ -2,7 +2,7 @@ use hyper::upgrade::OnUpgrade;
 
 use crate::transport_layer::TransportLayerType;
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct TestResponseWebSocket {
     pub maybe_on_upgrade: Option<OnUpgrade>,
     pub transport_type: TransportLayerType,

--- a/src/multipart/multipart_form.rs
+++ b/src/multipart/multipart_form.rs
@@ -5,6 +5,7 @@ use rust_multipart_rfc7578_2::client::multipart::Form;
 use std::fmt::Display;
 use std::io::Cursor;
 
+#[derive(Debug)]
 pub struct MultipartForm {
     inner: Form<'static>,
 }
@@ -32,8 +33,13 @@ impl MultipartForm {
         N: Display,
     {
         let reader = Cursor::new(part.bytes);
-        self.inner
-            .add_reader_2(name, reader, part.file_name, Some(part.mime_type));
+        self.inner.add_reader_2(
+            name,
+            reader,
+            part.file_name,
+            Some(part.mime_type),
+            part.headers,
+        );
 
         self
     }

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -132,7 +132,7 @@ use std::path::Path;
 /// # }
 /// ```
 ///
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct TestResponse {
     method: Method,
 

--- a/src/test_web_socket.rs
+++ b/src/test_web_socket.rs
@@ -17,6 +17,7 @@ use tokio_tungstenite::WebSocketStream;
 #[cfg(feature = "pretty-assertions")]
 use pretty_assertions::assert_eq;
 
+#[derive(Debug)]
 pub struct TestWebSocket {
     stream: WebSocketStream<TokioIo<Upgraded>>,
 }

--- a/src/transport_layer/transport_layer_builder.rs
+++ b/src/transport_layer/transport_layer_builder.rs
@@ -7,6 +7,7 @@ use tokio::net::TcpListener;
 
 use crate::internals::StartingTcpSetup;
 
+#[derive(Debug, Clone)]
 pub struct TransportLayerBuilder {
     ip: Option<IpAddr>,
     port: Option<u16>,

--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ cargo +stable test  --features all "$@"
 cargo +stable test "$@"
 
 # Check minimum version works, excluding shuttle
-cargo +1.78 check --features "pretty-assertions,yaml,msgpack,reqwest,typed-routing,ws"
+cargo +1.83 check --features "pretty-assertions,yaml,msgpack,reqwest,typed-routing,ws"
 # Check nightly also works, see https://github.com/JosephLenton/axum-test/issues/133
 cargo +nightly check --features all "$@"
 


### PR DESCRIPTION
# Changes

 * Update dependencies to the latest.
 * Require Rust 1.83
 * Add `multipart::Part::add_header`

# Comments

Fixes #141 
