### PR TITLE
fix: revert change to TestResponse::assert_json_contains change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "18.0.0"
+version = "18.0.1"
 rust-version = "1.83"
 edition = "2021"
 license = "MIT"
@@ -54,7 +54,7 @@ anyhow = "1.0"
 bytes = "1.10"
 bytesize = "2.0"
 cookie = "0.18"
-expect-json = { version = "1.3.0", path = "../expect-json/expect-json" }
+expect-json = { version = "1.5.0", path = "../expect-json/expect-json" }
 http = "1.3"
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["client", "http1", "client-legacy"] }

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Querying your application on the `TestServer` supports all of the common request
  - Typed Routing from Axum Extra
  - Reqwest integration
 
-## Contributions
+## ❤️ Contributions
 
 A big thanks to all of these who have helped!
 
@@ -113,4 +113,4 @@ A big thanks to all of these who have helped!
   <img src="https://contrib.rocks/image?repo=josephlenton/axum-test" />
 </a>
 
-Made with [contrib.rocks](https://contrib.rocks).
+Made with [contrib.rocks](https://contrib.rocks)


### PR DESCRIPTION
# Changes

 * Revert change to `TestResponse::assert_json_contains`, to still propagate to child objects by default.

fixes #151 
