### PR TITLE
fix: remove dangling path dependency on `expect-json`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ anyhow = "1.0"
 bytes = "1.10"
 bytesize = "2.0"
 cookie = "0.18"
-expect-json = { version = "1.5.0", path = "../expect-json/expect-json" }
+expect-json = "1.5.0"
 http = "1.3"
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["client", "http1", "client-legacy"] }


### PR DESCRIPTION
This PR fixes a dangling path dependency on `expect-json` which makes it impossible for anyone that doesn't have that crate at that specific path to build the project.

