### PR TITLE
feat!: make `TestRequest::IntoFuture` `Send`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ reqwest = ["dep:reqwest"]
 old-json-diff = ["dep:assert-json-diff"]
 
 [dependencies]
-auto-future = "1.0"
 axum = { version = "0.8.4", features = [] }
 anyhow = "1.0"
 bytes = "1.10"

--- a/src/internals/transport_layer/http_transport_layer.rs
+++ b/src/internals/transport_layer/http_transport_layer.rs
@@ -41,7 +41,7 @@ impl TransportLayer for HttpTransportLayer {
     fn send<'a>(
         &'a self,
         request: Request<Body>,
-    ) -> Pin<Box<dyn 'a + Future<Output = Result<Response<Body>>>>> {
+    ) -> Pin<Box<dyn 'a + Future<Output = Result<Response<Body>>> + Send>> {
         Box::pin(async {
             let client = Client::builder(hyper_util::rt::TokioExecutor::new()).build_http();
             let hyper_response = client.request(request).await?;

--- a/src/internals/transport_layer/mock_transport_layer.rs
+++ b/src/internals/transport_layer/mock_transport_layer.rs
@@ -35,13 +35,14 @@ where
     S: Service<Request<Body>, Response = RouterService> + Clone + Send + Sync + 'static,
     AnyhowError: From<S::Error>,
     S::Future: Send + Sync,
-    RouterService: Service<Request<Body>, Response = AxumResponse>,
+    RouterService: Service<Request<Body>, Response = AxumResponse> + Send,
+    RouterService::Future: Send,
     AnyhowError: From<RouterService::Error>,
 {
     fn send<'a>(
         &'a self,
         request: Request<Body>,
-    ) -> Pin<Box<dyn 'a + Future<Output = Result<Response<Body>>>>> {
+    ) -> Pin<Box<dyn 'a + Future<Output = Result<Response<Body>>> + Send>> {
         Box::pin(async {
             let body: Body = Bytes::new().into();
             let empty_request = Request::builder()

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Error as AnyhowError;
 use anyhow::Result;
-use auto_future::AutoFuture;
 use axum::body::Body;
 use bytes::Bytes;
 use cookie::time::OffsetDateTime;
@@ -21,9 +20,10 @@ use std::fmt::Display;
 use std::fs::read;
 use std::fs::read_to_string;
 use std::fs::File;
-use std::future::IntoFuture;
+use std::future::{Future, IntoFuture};
 use std::io::BufReader;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
 use url::Url;
@@ -833,10 +833,10 @@ impl TryFrom<TestRequest> for Request<Body> {
 
 impl IntoFuture for TestRequest {
     type Output = TestResponse;
-    type IntoFuture = AutoFuture<TestResponse>;
+    type IntoFuture = Pin<Box<dyn Future<Output = TestResponse> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
-        AutoFuture::new(async { self.send().await.context("Sending request failed").unwrap() })
+        Box::pin(async { self.send().await.context("Sending request failed").unwrap() })
     }
 }
 

--- a/src/transport_layer/transport_layer.rs
+++ b/src/transport_layer/transport_layer.rs
@@ -13,7 +13,7 @@ pub trait TransportLayer: Debug + Send + Sync + 'static {
     fn send<'a>(
         &'a self,
         request: Request<Body>,
-    ) -> Pin<Box<dyn 'a + Future<Output = Result<Response<Body>>>>>;
+    ) -> Pin<Box<dyn 'a + Future<Output = Result<Response<Body>>> + Send>>;
 
     fn url(&self) -> Option<&Url> {
         None


### PR DESCRIPTION
Problem: I need to create a `TestRequest` which I `await` on a background task. This is currently not possible because `TestRequest::IntoFuture` is not `Send`.

Solution: Replace the `AutoFuture` with its inner representation (a boxed future) and add a `Send` bound to it.

Note that this change is not API compatible, not only because the type of `TestRequest::IntoFuture` has changed but also because I had to bind the future returned by `TransportLayer::send` to `Send`. Not sure if that's acceptable or if not having a `Send` bound was an intentional design choice.