### PR TITLE
fix: remove doc_auto_cfg as it is no longer supported

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "18.2.0"
+version = "18.2.1"
 rust-version = "1.83"
 edition = "2021"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 #![allow(clippy::derivable_impls)]
 #![allow(clippy::manual_range_contains)]
 #![forbid(unsafe_code)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub(crate) mod internals;
 


### PR DESCRIPTION
# Changes

 * Remove `doc_auto_cfg` as it is no longer supported.

# Comments

Docs.rs builds failed due to having this.

