### PR TITLE
docs: update to latest expect-json docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "18.4.0"
+version = "18.4.1"
 rust-version = "1.85"
 edition = "2024"
 license = "MIT"
@@ -53,7 +53,7 @@ anyhow = "1.0"
 bytes = "1.11"
 bytesize = "2.3"
 cookie = "0.18"
-expect-json = "1.6.0"
+expect-json = "1.7.1"
 http = "1.3"
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["client", "http1", "client-legacy"] }


### PR DESCRIPTION
# Changes

 * Update to expect-json 1.7.1 for latest doc changes.
