### PR TITLE
feat: reqwest now fully shares cookies with axum-test

### DIFF
--- a/src/internals/cookies/atomic_cross_cookie_jar.rs
+++ b/src/internals/cookies/atomic_cross_cookie_jar.rs
@@ -1,0 +1,112 @@
+use crate::internals::CrossCookieJar;
+use crate::internals::ErrorMessage;
+use anyhow::Result;
+use cookie::Cookie;
+use cookie::CookieJar;
+use http::HeaderValue;
+#[cfg(feature = "reqwest")]
+use reqwest::cookie::CookieStore;
+use std::sync::Mutex;
+
+#[derive(Debug)]
+pub struct AtomicCrossCookieJar {
+    inner: Mutex<CrossCookieJar>,
+}
+
+impl AtomicCrossCookieJar {
+    pub fn new(is_saving_cookies: bool) -> Self {
+        Self {
+            inner: Mutex::new(CrossCookieJar::new(is_saving_cookies)),
+        }
+    }
+
+    pub fn is_saving(&self) -> bool {
+        self.inner
+            .lock()
+            .error_message("Failed to lock CookieJar")
+            .is_saving()
+    }
+
+    pub fn enable_saving(&self) {
+        self.inner
+            .lock()
+            .error_message("Failed to lock CookieJar")
+            .enable_saving();
+    }
+
+    pub fn disable_saving(&self) {
+        self.inner
+            .lock()
+            .error_message("Failed to lock CookieJar")
+            .disable_saving();
+    }
+
+    pub fn clear_cookies(&self) {
+        self.inner
+            .lock()
+            .error_message("Failed to lock CookieJar")
+            .clear_cookies();
+    }
+
+    pub fn add_cookie(&self, cookie: Cookie) {
+        self.inner
+            .lock()
+            .error_message("Failed to lock CookieJar")
+            .add_cookie(cookie);
+    }
+
+    pub fn add_cookies_by_jar(&self, cookies: CookieJar) {
+        self.inner
+            .lock()
+            .error_message("Failed to lock CookieJar")
+            .add_cookies_by_jar(cookies);
+    }
+
+    pub fn add_cookies_by_headers<'a, I>(&self, cookie_headers: I) -> Result<()>
+    where
+        I: Iterator<Item = &'a HeaderValue>,
+    {
+        self.inner
+            .lock()
+            .error_message("Failed to lock CookieJar")
+            .add_cookies_by_headers(cookie_headers)
+    }
+
+    #[cfg(feature = "reqwest")]
+    pub fn save_cookies_by_headers<'a, I>(&self, cookie_headers: I) -> Result<()>
+    where
+        I: Iterator<Item = &'a HeaderValue>,
+    {
+        self.inner
+            .lock()
+            .error_message("Failed to lock CookieJar")
+            .save_cookies_by_headers(cookie_headers)
+    }
+
+    #[cfg(feature = "reqwest")]
+    pub fn to_header_value(&self) -> Option<HeaderValue> {
+        self.inner
+            .lock()
+            .error_message("Failed to lock CookieJar")
+            .to_header_value()
+    }
+
+    pub fn to_cookie_jar(&self) -> CookieJar {
+        self.inner
+            .lock()
+            .error_message("Failed to lock CookieJar")
+            .to_cookie_jar()
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl CookieStore for AtomicCrossCookieJar {
+    fn set_cookies(&self, cookie_headers: &mut dyn Iterator<Item = &HeaderValue>, _url: &Url) {
+        self.save_cookies_by_headers(cookie_headers)
+            .error_message("Failed to save cookies from headers");
+    }
+
+    fn cookies(&self, _url: &Url) -> Option<HeaderValue> {
+        self.to_header_value()
+    }
+}

--- a/src/internals/cookies/cross_cookie_jar.rs
+++ b/src/internals/cookies/cross_cookie_jar.rs
@@ -1,0 +1,98 @@
+use crate::internals::ErrorMessage;
+use anyhow::Result;
+use cookie::Cookie;
+use cookie::CookieJar;
+use http::HeaderValue;
+
+#[derive(Debug, Clone)]
+pub struct CrossCookieJar {
+    is_saving_cookies: bool,
+    inner: CookieJar,
+}
+
+impl CrossCookieJar {
+    pub fn new(is_saving_cookies: bool) -> Self {
+        Self {
+            is_saving_cookies,
+            inner: CookieJar::new(),
+        }
+    }
+
+    pub fn is_saving(&mut self) -> bool {
+        self.is_saving_cookies
+    }
+
+    pub fn enable_saving(&mut self) {
+        self.is_saving_cookies = true;
+    }
+
+    pub fn disable_saving(&mut self) {
+        self.is_saving_cookies = false;
+    }
+
+    pub fn clear_cookies(&mut self) {
+        self.inner = CookieJar::new();
+    }
+
+    pub fn add_cookie(&mut self, cookie: Cookie) {
+        self.inner.add(cookie.into_owned());
+    }
+
+    pub fn add_cookies_by_jar(&mut self, cookies: CookieJar) {
+        for cookie in cookies.iter() {
+            self.inner.add(cookie.to_owned());
+        }
+    }
+
+    /// Adds the given cookies.
+    ///
+    /// They will be stored over the top of the existing cookies.
+    pub fn add_cookies_by_headers<'a, I>(&mut self, cookie_headers: I) -> Result<()>
+    where
+        I: Iterator<Item = &'a HeaderValue>,
+    {
+        for cookie_header in cookie_headers {
+            let cookie_header_str = cookie_header
+                .to_str()
+                .error_message("Reading cookie header for storing in the `TestServer`");
+
+            let cookie = Cookie::parse(cookie_header_str)?.into_owned();
+            self.inner.add(cookie);
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "reqwest")]
+    pub fn save_cookies_by_headers<'a, I>(&mut self, cookie_headers: I) -> Result<()>
+    where
+        I: Iterator<Item = &'a HeaderValue>,
+    {
+        if !self.is_saving_cookies {
+            return Ok(());
+        }
+
+        self.add_cookies_by_headers(cookie_headers)
+    }
+
+    #[cfg(feature = "reqwest")]
+    pub fn to_header_value(&self) -> Option<HeaderValue> {
+        let cookie_string = self
+            .inner
+            .iter()
+            .map(|c| format!("{}={}", c.name(), c.value()))
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        if cookie_string.is_empty() {
+            return None;
+        }
+
+        let header_value = HeaderValue::from_str(&cookie_string).unwrap();
+        Some(header_value)
+    }
+
+    pub fn to_cookie_jar(&self) -> CookieJar {
+        self.inner.clone()
+    }
+}

--- a/src/internals/cookies/mod.rs
+++ b/src/internals/cookies/mod.rs
@@ -1,0 +1,5 @@
+mod atomic_cross_cookie_jar;
+pub use self::atomic_cross_cookie_jar::*;
+
+mod cross_cookie_jar;
+pub use self::cross_cookie_jar::*;

--- a/src/internals/mod.rs
+++ b/src/internals/mod.rs
@@ -1,6 +1,9 @@
 mod transport_layer;
 pub use self::transport_layer::*;
 
+mod cookies;
+pub use self::cookies::*;
+
 #[cfg(feature = "ws")]
 mod websockets;
 #[cfg(feature = "ws")]

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -1,3 +1,9 @@
+use crate::TestResponse;
+use crate::internals::ExpectedState;
+use crate::internals::QueryParamsStore;
+use crate::internals::RequestPathFormatter;
+use crate::multipart::MultipartForm;
+use crate::transport_layer::TransportLayer;
 use anyhow::Context;
 use anyhow::Error as AnyhowError;
 use anyhow::Result;
@@ -25,16 +31,7 @@ use std::io::BufReader;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::Mutex;
 use url::Url;
-
-use crate::ServerSharedState;
-use crate::TestResponse;
-use crate::internals::ExpectedState;
-use crate::internals::QueryParamsStore;
-use crate::internals::RequestPathFormatter;
-use crate::multipart::MultipartForm;
-use crate::transport_layer::TransportLayer;
 
 mod test_request_config;
 pub(crate) use self::test_request_config::*;
@@ -111,26 +108,17 @@ pub(crate) use self::test_request_config::*;
 #[must_use = "futures do nothing unless polled"]
 pub struct TestRequest {
     config: TestRequestConfig,
-
-    server_state: Arc<Mutex<ServerSharedState>>,
     transport: Arc<Box<dyn TransportLayer>>,
-
     body: Option<Body>,
-
     expected_state: ExpectedState,
 }
 
 impl TestRequest {
-    pub(crate) fn new(
-        server_state: Arc<Mutex<ServerSharedState>>,
-        transport: Arc<Box<dyn TransportLayer>>,
-        config: TestRequestConfig,
-    ) -> Self {
+    pub(crate) fn new(transport: Arc<Box<dyn TransportLayer>>, config: TestRequestConfig) -> Self {
         let expected_state = config.expected_state;
 
         Self {
             config,
-            server_state,
             transport,
             body: None,
             expected_state,
@@ -724,7 +712,9 @@ impl TestRequest {
 
         if save_cookies {
             let cookie_headers = parts.headers.get_all(SET_COOKIE).into_iter();
-            ServerSharedState::add_cookies_by_header(&self.server_state, cookie_headers)?;
+            self.config
+                .atomic_cookie_jar
+                .add_cookies_by_headers(cookie_headers)?;
         }
 
         let test_response = TestResponse::new(
@@ -2019,46 +2009,9 @@ mod test_save_cookies {
 
     const TEST_COOKIE_NAME: &'static str = &"test-cookie";
 
-    async fn put_cookie_with_attributes(
-        mut cookies: AxumCookieJar,
-        request: Request,
-    ) -> (AxumCookieJar, &'static str) {
-        let body_bytes = request
-            .into_body()
-            .collect()
-            .await
-            .expect("Should turn the body into bytes")
-            .to_bytes();
-
-        let body_text: String = String::from_utf8_lossy(&body_bytes).to_string();
-        let cookie = Cookie::build((TEST_COOKIE_NAME, body_text))
-            .http_only(true)
-            .secure(true)
-            .same_site(SameSite::Strict)
-            .path("/cookie")
-            .build();
-        cookies = cookies.add(cookie);
-
-        (cookies, &"done")
-    }
-
-    async fn get_cookie_headers_joined(headers: HeaderMap) -> String {
-        let cookies: String = headers
-            .get_all("cookie")
-            .into_iter()
-            .map(|c| c.to_str().unwrap_or("").to_string())
-            .reduce(|a, b| a + "; " + &b)
-            .unwrap_or_else(|| String::new());
-
-        cookies
-    }
-
     #[tokio::test]
-    async fn it_should_strip_cookies_from_their_attributes() {
-        let app = Router::new()
-            .route("/cookie", put(put_cookie_with_attributes))
-            .route("/cookie", get(get_cookie_headers_joined));
-        let server = TestServer::new(app).expect("Should create test server");
+    async fn it_should_save_cookies_across_requests_when_enabled() {
+        let server = TestServer::new(app()).expect("Should create test server");
 
         // Create a cookie.
         server
@@ -2071,6 +2024,46 @@ mod test_save_cookies {
         let response_text = server.get(&"/cookie").await.text();
 
         assert_eq!(response_text, format!("{}=cookie-found!", TEST_COOKIE_NAME));
+    }
+
+    fn app() -> Router {
+        async fn put_cookie_with_attributes(
+            mut cookies: AxumCookieJar,
+            request: Request,
+        ) -> (AxumCookieJar, &'static str) {
+            let body_bytes = request
+                .into_body()
+                .collect()
+                .await
+                .expect("Should turn the body into bytes")
+                .to_bytes();
+
+            let body_text: String = String::from_utf8_lossy(&body_bytes).to_string();
+            let cookie = Cookie::build((TEST_COOKIE_NAME, body_text))
+                .http_only(true)
+                .secure(true)
+                .same_site(SameSite::Strict)
+                .path("/cookie")
+                .build();
+            cookies = cookies.add(cookie);
+
+            (cookies, &"done")
+        }
+
+        async fn get_cookie_headers_joined(headers: HeaderMap) -> String {
+            let cookies: String = headers
+                .get_all("cookie")
+                .into_iter()
+                .map(|c| c.to_str().unwrap_or("").to_string())
+                .reduce(|a, b| a + "; " + &b)
+                .unwrap_or_else(|| String::new());
+
+            cookies
+        }
+
+        Router::new()
+            .route("/cookie", put(put_cookie_with_attributes))
+            .route("/cookie", get(get_cookie_headers_joined))
     }
 }
 

--- a/src/test_request/test_request_config.rs
+++ b/src/test_request/test_request_config.rs
@@ -4,11 +4,15 @@ use http::HeaderValue;
 use http::Method;
 use url::Url;
 
+use crate::internals::AtomicCrossCookieJar;
 use crate::internals::ExpectedState;
 use crate::internals::QueryParamsStore;
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct TestRequestConfig {
+    pub atomic_cookie_jar: Arc<AtomicCrossCookieJar>,
+
     pub is_saving_cookies: bool,
     pub expected_state: ExpectedState,
     pub content_type: Option<String>,

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -1,3 +1,15 @@
+use crate::TestRequest;
+use crate::TestRequestConfig;
+use crate::TestServerBuilder;
+use crate::TestServerConfig;
+use crate::Transport;
+use crate::internals::AtomicCrossCookieJar;
+use crate::internals::ExpectedState;
+use crate::internals::QueryParamsStore;
+use crate::internals::RequestPathFormatter;
+use crate::transport_layer::IntoTransportLayer;
+use crate::transport_layer::TransportLayer;
+use crate::transport_layer::TransportLayerBuilder;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
@@ -22,18 +34,8 @@ use crate::transport_layer::TransportLayerType;
 use reqwest::Client;
 #[cfg(feature = "reqwest")]
 use reqwest::RequestBuilder;
-
-use crate::TestRequest;
-use crate::TestRequestConfig;
-use crate::TestServerBuilder;
-use crate::TestServerConfig;
-use crate::Transport;
-use crate::internals::ExpectedState;
-use crate::internals::QueryParamsStore;
-use crate::internals::RequestPathFormatter;
-use crate::transport_layer::IntoTransportLayer;
-use crate::transport_layer::TransportLayer;
-use crate::transport_layer::TransportLayerBuilder;
+#[cfg(feature = "reqwest")]
+use std::cell::OnceCell;
 
 mod server_shared_state;
 pub(crate) use self::server_shared_state::*;
@@ -141,14 +143,14 @@ const DEFAULT_URL_ADDRESS: &str = "http://localhost";
 #[derive(Debug)]
 pub struct TestServer {
     state: Arc<Mutex<ServerSharedState>>,
+    cookie_jar: Arc<AtomicCrossCookieJar>,
     transport: Arc<Box<dyn TransportLayer>>,
-    save_cookies: bool,
     expected_state: ExpectedState,
     default_content_type: Option<String>,
     is_http_path_restricted: bool,
 
     #[cfg(feature = "reqwest")]
-    maybe_reqwest_client: Option<Client>,
+    maybe_reqwest_client: OnceCell<Client>,
 }
 
 impl TestServer {
@@ -241,30 +243,16 @@ impl TestServer {
             false => ExpectedState::None,
         };
 
-        #[cfg(feature = "reqwest")]
-        let maybe_reqwest_client = match transport.transport_layer_type() {
-            TransportLayerType::Http => {
-                let reqwest_client = reqwest::Client::builder()
-                    .redirect(reqwest::redirect::Policy::none())
-                    .cookie_store(config.save_cookies)
-                    .build()
-                    .expect("Failed to build Reqwest Client");
-
-                Some(reqwest_client)
-            }
-            TransportLayerType::Mock => None,
-        };
-
         Ok(Self {
             state,
+            cookie_jar: Arc::new(AtomicCrossCookieJar::new(config.save_cookies)),
             transport,
-            save_cookies: config.save_cookies,
             expected_state,
             default_content_type: config.default_content_type,
             is_http_path_restricted: config.restrict_requests_with_http_schema,
 
             #[cfg(feature = "reqwest")]
-            maybe_reqwest_client,
+            maybe_reqwest_client: Default::default(),
         })
     }
 
@@ -300,14 +288,22 @@ impl TestServer {
             .with_context(|| format!("Failed to build, for request {method} {path}"))
             .unwrap();
 
-        TestRequest::new(self.state.clone(), self.transport.clone(), config)
+        TestRequest::new(self.transport.clone(), config)
     }
 
     #[cfg(feature = "reqwest")]
     fn reqwest_client(&self) -> &Client {
-        self.maybe_reqwest_client
-            .as_ref()
-            .expect("Reqwest client is not available, TestServer must be build with HTTP transport for Reqwest to be available")
+        self.maybe_reqwest_client.get_or_init(|| {
+            if self.transport.transport_layer_type() == TransportLayerType::Mock {
+                panic!("Reqwest client is not available, TestServer must be build with HTTP transport for Reqwest to be available");
+            }
+
+            reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .cookie_provider(self.cookie_jar.clone())
+                .build()
+                .expect("Failed to build Reqwest Client")
+        })
     }
 
     #[cfg(feature = "reqwest")]
@@ -612,9 +608,7 @@ impl TestServer {
     /// If a cookie with the same name already exists,
     /// then it will be replaced.
     pub fn add_cookie(&mut self, cookie: Cookie) {
-        ServerSharedState::add_cookie(&self.state, cookie)
-            .context("Trying to call add_cookie")
-            .unwrap()
+        self.cookie_jar.add_cookie(cookie);
     }
 
     /// Adds extra cookies to be used on *all* future requests.
@@ -622,30 +616,28 @@ impl TestServer {
     /// Any cookies which have the same name as the new cookies,
     /// will get replaced.
     pub fn add_cookies(&mut self, cookies: CookieJar) {
-        ServerSharedState::add_cookies(&self.state, cookies)
-            .context("Trying to call add_cookies")
-            .unwrap()
+        self.cookie_jar.add_cookies_by_jar(cookies);
     }
 
     /// Clears all of the cookies stored internally.
     pub fn clear_cookies(&mut self) {
-        ServerSharedState::clear_cookies(&self.state)
-            .context("Trying to call clear_cookies")
-            .unwrap()
+        self.cookie_jar.clear_cookies();
     }
 
     /// Requests made using this `TestServer` will save their cookies for future requests to send.
+    /// Including sharing cookies with requests made using the `reqwest` feature.
     ///
     /// This behaviour is off by default.
     pub fn save_cookies(&mut self) {
-        self.save_cookies = true;
+        self.cookie_jar.enable_saving();
     }
 
     /// Requests made using this `TestServer` will _not_ save their cookies for future requests to send up.
+    /// Including sharing cookies with requests made using the `reqwest` feature.
     ///
     /// This is the default behaviour.
     pub fn do_not_save_cookies(&mut self) {
-        self.save_cookies = false;
+        self.cookie_jar.disable_saving();
     }
 
     /// Requests made using this `TestServer` will assert a HTTP status in the 2xx range will be returned, unless marked otherwise.
@@ -791,7 +783,6 @@ impl TestServer {
             )
         })?;
 
-        let cookies = server_locked.cookies().clone();
         let mut query_params = server_locked.query_params().clone();
         let headers = server_locked.headers().clone();
         let mut full_request_url =
@@ -807,13 +798,18 @@ impl TestServer {
         ::std::mem::drop(server_locked);
 
         Ok(TestRequestConfig {
-            is_saving_cookies: self.save_cookies,
+            atomic_cookie_jar: self.cookie_jar.clone(),
+
+            // These are copied over from the cookie jar,
+            // as the server could change it's save state after the request is made.
+            is_saving_cookies: self.cookie_jar.is_saving(),
+            cookies: self.cookie_jar.to_cookie_jar(),
+
             expected_state: self.expected_state,
             content_type: self.default_content_type.clone(),
             method,
 
             full_request_url,
-            cookies,
             query_params,
             headers,
         })
@@ -1570,7 +1566,6 @@ mod test_server_url {
 #[cfg(test)]
 mod test_add_cookie {
     use crate::TestServer;
-
     use axum::Router;
     use axum::routing::get;
     use axum_extra::extract::cookie::CookieJar;
@@ -2684,5 +2679,199 @@ mod test_is_running {
 
         assert!(!server.is_running());
         server.get("/ping").await.assert_status_ok();
+    }
+}
+
+#[cfg(test)]
+mod test_save_cookies {
+    use crate::TestServer;
+    use axum::Router;
+    use axum::extract::Request;
+    use axum::http::header::HeaderMap;
+    use axum::routing::get;
+    use axum::routing::put;
+    use axum_extra::extract::cookie::CookieJar as AxumCookieJar;
+    use cookie::Cookie;
+    use cookie::SameSite;
+    use http_body_util::BodyExt;
+
+    const TEST_COOKIE_NAME: &'static str = &"test-cookie";
+
+    #[tokio::test]
+    async fn it_should_save_cookies_across_requests_when_enabled() {
+        let mut server = TestServer::new(app()).expect("Should create test server");
+
+        server.save_cookies();
+
+        save_cookie_using_axum_test(&server).await;
+        assert_cookie_using_axum_test(&server).await;
+    }
+
+    #[cfg(feature = "reqwest")]
+    #[tokio::test]
+    async fn it_should_save_cookies_across_reqwest_requests_when_enabled() {
+        let mut server = TestServer::builder()
+            .http_transport()
+            .build(app())
+            .expect("Should create test server");
+
+        server.save_cookies();
+
+        save_cookie_using_reqwest(&server).await;
+        save_cookie_using_reqwest(&server).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_save_cookies_across_axum_test_requests_when_enabled_for_second_request() {
+        let mut server = TestServer::builder()
+            .http_transport()
+            .build(app())
+            .expect("Should create test server");
+
+        save_cookie_using_axum_test(&server).await;
+        assert_no_cookie_using_axum_test(&server).await;
+
+        server.save_cookies();
+
+        save_cookie_using_axum_test(&server).await;
+        assert_cookie_using_axum_test(&server).await;
+    }
+
+    #[cfg(feature = "reqwest")]
+    #[tokio::test]
+    async fn it_should_save_cookies_across_reqwest_requests_when_enabled_for_second_request() {
+        let mut server = TestServer::builder()
+            .http_transport()
+            .build(app())
+            .expect("Should create test server");
+
+        save_cookie_using_reqwest(&server).await;
+        assert_no_cookie_using_reqwest(&server).await;
+
+        server.save_cookies();
+
+        save_cookie_using_reqwest(&server).await;
+        assert_cookie_using_reqwest(&server).await;
+    }
+
+    #[cfg(feature = "reqwest")]
+    #[tokio::test]
+    async fn it_should_save_cookies_when_set_by_reqwest_and_read_by_axum_test() {
+        let mut server = TestServer::builder()
+            .http_transport()
+            .build(app())
+            .expect("Should create test server");
+
+        server.save_cookies();
+
+        save_cookie_using_reqwest(&server).await;
+        assert_cookie_using_axum_test(&server).await;
+    }
+
+    #[cfg(feature = "reqwest")]
+    #[tokio::test]
+    async fn it_should_save_cookies_when_set_by_axum_test_and_read_by_reqwest() {
+        let mut server = TestServer::builder()
+            .http_transport()
+            .build(app())
+            .expect("Should create test server");
+
+        server.save_cookies();
+
+        save_cookie_using_axum_test(&server).await;
+        assert_cookie_using_reqwest(&server).await;
+    }
+
+    fn app() -> Router {
+        async fn put_cookie_with_attributes(
+            mut cookies: AxumCookieJar,
+            request: Request,
+        ) -> (AxumCookieJar, &'static str) {
+            let body_bytes = request
+                .into_body()
+                .collect()
+                .await
+                .expect("Should turn the body into bytes")
+                .to_bytes();
+
+            let body_text: String = String::from_utf8_lossy(&body_bytes).to_string();
+            let cookie = Cookie::build((TEST_COOKIE_NAME, body_text))
+                .http_only(true)
+                .secure(true)
+                .same_site(SameSite::Strict)
+                .path("/cookie")
+                .build();
+            cookies = cookies.add(cookie);
+
+            (cookies, &"done")
+        }
+
+        async fn get_cookie_headers_joined(headers: HeaderMap) -> String {
+            let cookies: String = headers
+                .get_all("cookie")
+                .into_iter()
+                .map(|c| c.to_str().unwrap_or("").to_string())
+                .reduce(|a, b| a + "; " + &b)
+                .unwrap_or_else(|| String::new());
+
+            cookies
+        }
+
+        Router::new()
+            .route("/cookie", put(put_cookie_with_attributes))
+            .route("/cookie", get(get_cookie_headers_joined))
+    }
+
+    async fn save_cookie_using_axum_test(server: &TestServer) {
+        server.put(&"/cookie").text(&"cookie-found!").await;
+    }
+
+    #[cfg(feature = "reqwest")]
+    async fn save_cookie_using_reqwest(server: &TestServer) {
+        server
+            .reqwest_put(&"/cookie")
+            .body("cookie-found!".to_string())
+            .send()
+            .await
+            .unwrap();
+    }
+
+    async fn assert_cookie_using_axum_test(server: &TestServer) {
+        server
+            .get(&"/cookie")
+            .await
+            .assert_text("test-cookie=cookie-found!");
+    }
+
+    #[cfg(feature = "reqwest")]
+    async fn assert_cookie_using_reqwest(server: &TestServer) {
+        let response_text = server
+            .reqwest_get(&"/cookie")
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+        assert_eq!("test-cookie=cookie-found!", response_text);
+    }
+
+    async fn assert_no_cookie_using_axum_test(server: &TestServer) {
+        server.get(&"/cookie").await.assert_text("");
+    }
+
+    #[cfg(feature = "reqwest")]
+    async fn assert_no_cookie_using_reqwest(server: &TestServer) {
+        let response_text = server
+            .reqwest_get(&"/cookie")
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+        assert_eq!("", response_text);
     }
 }

--- a/src/test_server/server_shared_state.rs
+++ b/src/test_server/server_shared_state.rs
@@ -1,20 +1,15 @@
-use anyhow::Context;
+use crate::internals::QueryParamsStore;
+use crate::internals::with_this_mut;
 use anyhow::Result;
-use cookie::Cookie;
-use cookie::CookieJar;
 use http::HeaderName;
 use http::HeaderValue;
 use serde::Serialize;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use crate::internals::QueryParamsStore;
-use crate::internals::with_this_mut;
-
 #[derive(Debug)]
 pub(crate) struct ServerSharedState {
     scheme: Option<String>,
-    cookies: CookieJar,
     query_params: QueryParamsStore,
     headers: Vec<(HeaderName, HeaderValue)>,
 }
@@ -23,7 +18,6 @@ impl ServerSharedState {
     pub(crate) fn new() -> Self {
         Self {
             scheme: None,
-            cookies: CookieJar::new(),
             query_params: QueryParamsStore::new(),
             headers: Vec::new(),
         }
@@ -33,67 +27,12 @@ impl ServerSharedState {
         self.scheme.as_deref()
     }
 
-    pub(crate) fn cookies(&self) -> &CookieJar {
-        &self.cookies
-    }
-
     pub(crate) fn query_params(&self) -> &QueryParamsStore {
         &self.query_params
     }
 
     pub(crate) fn headers(&self) -> &Vec<(HeaderName, HeaderValue)> {
         &self.headers
-    }
-
-    /// Adds the given cookies.
-    ///
-    /// They will be stored over the top of the existing cookies.
-    pub(crate) fn add_cookies_by_header<'a, I>(
-        this: &Arc<Mutex<Self>>,
-        cookie_headers: I,
-    ) -> Result<()>
-    where
-        I: Iterator<Item = &'a HeaderValue>,
-    {
-        with_this_mut(this, "add_cookies_by_header", |this| {
-            for cookie_header in cookie_headers {
-                let cookie_header_str = cookie_header
-                    .to_str()
-                    .context("Reading cookie header for storing in the `TestServer`")
-                    .unwrap();
-
-                let cookie: Cookie<'static> = Cookie::parse(cookie_header_str)?.into_owned();
-                this.cookies.add(cookie);
-            }
-
-            Ok(()) as Result<()>
-        })?
-    }
-
-    /// Adds the given cookies.
-    ///
-    /// They will be stored over the top of the existing cookies.
-    pub(crate) fn clear_cookies(this: &Arc<Mutex<Self>>) -> Result<()> {
-        with_this_mut(this, "clear_cookies", |this| {
-            this.cookies = CookieJar::new();
-        })
-    }
-
-    /// Adds the given cookies.
-    ///
-    /// They will be stored over the top of the existing cookies.
-    pub(crate) fn add_cookies(this: &Arc<Mutex<Self>>, cookies: CookieJar) -> Result<()> {
-        with_this_mut(this, "add_cookies", |this| {
-            for cookie in cookies.iter() {
-                this.cookies.add(cookie.to_owned());
-            }
-        })
-    }
-
-    pub(crate) fn add_cookie(this: &Arc<Mutex<Self>>, cookie: Cookie) -> Result<()> {
-        with_this_mut(this, "add_cookie", |this| {
-            this.cookies.add(cookie.into_owned());
-        })
     }
 
     pub(crate) fn add_query_params<V>(this: &Arc<Mutex<Self>>, query_params: V) -> Result<()>


### PR DESCRIPTION
# Changes

 * Reqwest and AxumTest now fully share cookies.
 * Changes to saving cookies in one, affects the other.

Implements #174 