### PR TITLE
chore: remove warning on unused safe send

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,7 +10,9 @@ pub use self::new_random_tcp_listener::*;
 mod new_random_tokio_tcp_listener;
 pub use self::new_random_tokio_tcp_listener::*;
 
+#[cfg(feature = "actix-web")]
 mod safe_send;
+#[cfg(feature = "actix-web")]
 pub(crate) use self::safe_send::*;
 
 mod spawn_serve;


### PR DESCRIPTION
# Changes

 * Remove clippy warning on the use of safe send.
