### PR TITLE
chore: bump tokio-tungstenite to 0.29.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ axum-extra = { version = "0.12.5", optional = true, features = ["routing", "type
 uuid = { version = "1.21.0", optional = true, features = ["v4"]}
 base64 = { version = "0.22.1", optional = true }
 futures-util = { version = "0.3.32", optional = true }
-tokio-tungstenite = { version = "0.28.0", optional = true }
+tokio-tungstenite = { version = "0.29.0", optional = true }
 
 # Reqwest
 reqwest = { version = "0.13.2", optional = true, features = ["cookies", "json", "stream", "multipart"] }
@@ -106,8 +106,8 @@ actix-web = { version = "4.13.0", optional = true }
 assert-json-diff = { version = "2.0.2", optional = true }
 
 [dev-dependencies]
-axum = { version = "0.8.8", features = ["multipart", "tokio", "ws"] }
-axum-extra = { version = "0.12.5", features = ["cookie", "typed-routing", "query"] }
+axum = { version = "0.8.9", features = ["multipart", "tokio", "ws"] }
+axum-extra = { version = "0.12.6", features = ["cookie", "typed-routing", "query"] }
 axum-msgpack = "0.5.0"
 axum-yaml = "0.5.0"
 futures = "0.3.32"


### PR DESCRIPTION
# Changes

 * chore: bump tungstenite and tokio-tungstenite to 0.29.0
 * chore: bump axum and axum-extra to use tungstenite 0.29.0
