### PR TITLE
feat: pretty print response body of content type `application/problem+json`

### DIFF
--- a/src/internals/debug_response_body.rs
+++ b/src/internals/debug_response_body.rs
@@ -16,7 +16,9 @@ impl Display for DebugResponseBody<'_> {
             Some(content_type) => {
                 match content_type.as_str() {
                     // Json
-                    "application/json" | "text/json" => write_json(f, self.0),
+                    "application/json" | "text/json" | "application/problem+json" => {
+                        write_json(f, self.0)
+                    }
 
                     // Msgpack
                     "application/msgpack" => write!(f, "<MsgPack>"),


### PR DESCRIPTION
When e.g. an expected response code is not present, the response body gets printed. Previously, only `application/json` and `text/json` were recognised as JSON responses. However, [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html) defines the content type `application/problem+json` as containing valid JSON, to be used in error cases.

# Changes

 * This adds the content type `application/problem+json` to the list of allowed content types for JSON formatting.

# Comments

We use the mechanism of RFC 9457 in our organisation and would like to introduce `axum-test` for our e2e testing. However, currently the DX is quite poor as e.g. when you have a test expecting a `201 Created` but instead receive an error we only see `with body <Unknown content type, with len 357 B>` in the error message generated by `axum-test`.

