### PR TITLE
Feat http with tcp listener

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "20.1.0"
+version = "21.0.0"
 rust-version = "1.88"
 edition = "2024"
 license = "MIT"
@@ -60,14 +60,15 @@ ws = ["axum/ws", "tokio/time", "dep:uuid", "dep:base64", "dep:tokio-tungstenite"
 [dependencies]
 axum = { version = "0.8.9", features = [] }
 anyhow = "1.0.102"
-bytes = "1.11.1"
-bytesize = "2.3.1"
+bytes = "1.12.0"
+bytesize = "2.4.0"
 cookie = "0.18.1"
+educe = { version = "0.6.0", default-features = false, features = ["Clone", "PartialEq"] }
 expect-json = "1.11.0"
-http = "1.4.1"
+http = "1.4.2"
 http-body-util = "0.1.3"
 hyper-util = { version = "0.1.20", features = ["client", "http1", "client-legacy"] }
-hyper = { version = "1.9.0", features = ["http1"] }
+hyper = { version = "1.10.1", features = ["http1"] }
 mime = "0.3.17"
 rust-multipart-rfc7578_2 = "0.9.0"
 reserve-port = "2.4.0"
@@ -91,7 +92,7 @@ rmp-serde = { version = "1.3.1", optional = true }
 axum-extra = { version = "0.12.6", optional = true, features = ["routing", "typed-routing"] }
 
 # WebSockets
-uuid = { version = "1.23.1", optional = true, features = ["v4"]}
+uuid = { version = "1.23.4", optional = true, features = ["v4"]}
 base64 = { version = "0.22.1", optional = true }
 futures-util = { version = "0.3.32", optional = true }
 tokio-tungstenite = { version = "0.29.0", optional = true }
@@ -100,7 +101,7 @@ tokio-tungstenite = { version = "0.29.0", optional = true }
 reqwest = { version = "0.13.4", optional = true, features = ["cookies", "json", "stream", "multipart"] }
 
 # Actix Web
-actix-web = { version = "4.13.0", optional = true }
+actix-web = { version = "4.14.0", optional = true }
 
 # Old Json Diff
 assert-json-diff = { version = "2.0.2", optional = true }
@@ -112,10 +113,10 @@ axum-msgpack = "0.5.0"
 axum-yaml = "0.5.0"
 futures = "0.3.32"
 futures-util = "0.3.32"
-insta = { version = "1.47.2", features = ["json"] }
+insta = { version = "1.48.0", features = ["json"] }
 rand = "0.10.1"
-regex = "1.12.3"
+regex = "1.12.4"
 actix-ws = "0.4.0"
 serde-email = { version = "3.2.0", features = ["serde"] }
-tokio = { version = "1.49.0", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
-tower-http = { version = "0.6.8", features = ["normalize-path"] }
+tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
+tower-http = { version = "0.7.0", features = ["normalize-path"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ hyper-util = { version = "0.1.20", features = ["client", "http1", "client-legacy
 hyper = { version = "1.10.1", features = ["http1"] }
 mime = "0.3.17"
 rust-multipart-rfc7578_2 = "0.9.0"
-reserve-port = "2.4.0"
+reserve-port = "2.5.0"
 serde = "1.0.228"
 serde_json = "1.0.150"
 serde_urlencoded = "0.7.1"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
   </h1>
 
   <h3>
-    Easy E2E testing for Axum (and Actix Web)<br/>
-    including REST, WebSockets, and more
+    Easy E2E testing for Axum<br/>
+    (and Actix Web),<br/>
+    REST, WebSockets, snapshots, and more
   </h3>
 
   [![crate](https://img.shields.io/crates/v/axum-test.svg)](https://crates.io/crates/axum-test)
@@ -71,8 +72,9 @@ Here is a list of compatability with prior versions:
 
 | Axum Version    | Axum Test Version |
 |-----------------|-------------------|
-| 0.8.9+ (latest) | 20.1.0 (latest)   |
-| 0.8.8.          | 20.0.0            |
+| 0.8.9+ (latest) | 21.0.0 (latest)   |
+| 0.8.9           | 20.1.0            |
+| 0.8.8           | 20.0.0            |
 | 0.8.8           | 19.0.0            |
 | 0.8.7           | 18.3.0            |
 | 0.8.4           | 18.0.0            |

--- a/src/internals/starting_tcp_setup.rs
+++ b/src/internals/starting_tcp_setup.rs
@@ -17,7 +17,23 @@ pub struct StartingTcpSetup {
 }
 
 impl StartingTcpSetup {
-    pub fn new(maybe_ip: Option<IpAddr>, maybe_port: Option<u16>) -> Result<Self> {
+    pub fn from_tcp_listener(std_tcp_listener: StdTcpListener) -> Result<Self> {
+        let socket_addr = std_tcp_listener
+            .local_addr()
+            .expect("Failed to get underlying socket address for TcpListener");
+        ReservedPort::reserve_port(socket_addr.port())?;
+
+        std_tcp_listener.set_nonblocking(true)?;
+        let tokio_tcp_listener = TokioTcpListener::from_std(std_tcp_listener)?;
+
+        Ok(Self {
+            maybe_reserved_port: None,
+            socket_addr,
+            tcp_listener: tokio_tcp_listener,
+        })
+    }
+
+    pub fn from_ip_port(maybe_ip: Option<IpAddr>, maybe_port: Option<u16>) -> Result<Self> {
         let ip = maybe_ip.unwrap_or(DEFAULT_IP_ADDRESS);
 
         maybe_port
@@ -65,7 +81,7 @@ mod test_new {
         let ip = None;
         let port = None;
 
-        let setup = StartingTcpSetup::new(ip, port).unwrap();
+        let setup = StartingTcpSetup::from_ip_port(ip, port).unwrap();
         let addr = setup.socket_addr.to_string();
 
         let regex = Regex::new("^127\\.0\\.0\\.1:[0-9]+$").unwrap();
@@ -78,7 +94,7 @@ mod test_new {
         let ip = Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
         let port = None;
 
-        let setup = StartingTcpSetup::new(ip, port).unwrap();
+        let setup = StartingTcpSetup::from_ip_port(ip, port).unwrap();
         let addr = setup.socket_addr.to_string();
 
         let regex = Regex::new("^127\\.0\\.0\\.1:[0-9]+$").unwrap();
@@ -91,7 +107,7 @@ mod test_new {
         let ip = None;
         let port = Some(8123);
 
-        let setup = StartingTcpSetup::new(ip, port).unwrap();
+        let setup = StartingTcpSetup::from_ip_port(ip, port).unwrap();
         let addr = setup.socket_addr.to_string();
 
         assert_eq!(addr, "127.0.0.1:8123");
@@ -102,7 +118,7 @@ mod test_new {
         let ip = Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
         let port = Some(8124);
 
-        let setup = StartingTcpSetup::new(ip, port).unwrap();
+        let setup = StartingTcpSetup::from_ip_port(ip, port).unwrap();
         let addr = setup.socket_addr.to_string();
 
         assert_eq!(addr, "127.0.0.1:8124");

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -231,17 +231,22 @@ impl TestServer {
 
         let transport = match config.transport {
             None => {
-                let builder = TransportLayerBuilder::new(None, None);
+                let builder = TransportLayerBuilder::from_ip_port(None, None);
                 let transport = app.into_default_transport(builder)?;
                 Arc::new(transport)
             }
             Some(Transport::HttpRandomPort) => {
-                let builder = TransportLayerBuilder::new(None, None);
+                let builder = TransportLayerBuilder::from_ip_port(None, None);
                 let transport = app.into_http_transport_layer(builder)?;
                 Arc::new(transport)
             }
             Some(Transport::HttpIpPort { ip, port }) => {
-                let builder = TransportLayerBuilder::new(ip, port);
+                let builder = TransportLayerBuilder::from_ip_port(ip, port);
+                let transport = app.into_http_transport_layer(builder)?;
+                Arc::new(transport)
+            }
+            Some(Transport::HttpTcpListner { tcp_listener }) => {
+                let builder = TransportLayerBuilder::from_tcp_listener(tcp_listener);
                 let transport = app.into_http_transport_layer(builder)?;
                 Arc::new(transport)
             }

--- a/src/test_server_builder.rs
+++ b/src/test_server_builder.rs
@@ -5,6 +5,7 @@ use crate::internals::ErrorMessage;
 use crate::transport_layer::IntoTransportLayer;
 use anyhow::Result;
 use std::net::IpAddr;
+use std::net::TcpListener as StdTcpListener;
 
 /// A builder for [`TestServer`]. Inside is a [`TestServerConfig`],
 /// configured by each method, and then turn into a server by [`TestServerBuilder::build`].
@@ -29,7 +30,7 @@ use std::net::IpAddr;
 /// # }
 /// ```
 ///
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TestServerBuilder {
     config: TestServerConfig,
 }
@@ -50,6 +51,10 @@ impl TestServerBuilder {
 
     pub fn http_transport_with_ip_port(self, ip: Option<IpAddr>, port: Option<u16>) -> Self {
         self.transport(Transport::HttpIpPort { ip, port })
+    }
+
+    pub fn http_transport_with_tcp_listener(self, tcp_listener: StdTcpListener) -> Self {
+        self.transport(Transport::HttpTcpListner { tcp_listener })
     }
 
     pub fn mock_transport(self) -> Self {

--- a/src/test_server_config.rs
+++ b/src/test_server_config.rs
@@ -40,7 +40,7 @@ use anyhow::Result;
 /// # }
 /// ```
 ///
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TestServerConfig {
     /// Which transport mode to use to process requests.
     /// For setting if the server should use mocked http (which uses [`tower::util::Oneshot`](tower::util::Oneshot)),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,8 +1,11 @@
+use educe::Educe;
 use std::net::IpAddr;
+use std::net::TcpListener;
 
 /// Transport is for setting which transport mode for the `TestServer`
 /// to use when making requests.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Educe, Default, Debug)]
+#[educe(Clone, PartialEq)]
 pub enum Transport {
     /// With this transport mode, `TestRequest` will use a mock HTTP
     /// transport.
@@ -32,4 +35,20 @@ pub enum Transport {
         /// **Defaults** to a _random_ port.
         port: Option<u16>,
     },
+
+    HttpTcpListner {
+        #[educe(
+            Clone(method(educe_clone_error)),
+            PartialEq(method(educe_return_false))
+        )]
+        tcp_listener: TcpListener,
+    },
+}
+
+const fn educe_clone_error(_: &TcpListener) -> TcpListener {
+    panic!("Transport::clone is not supported when holding a TcpListener")
+}
+
+const fn educe_return_false(_: &TcpListener, _: &TcpListener) -> bool {
+    false
 }

--- a/src/transport_layer/transport_layer_builder.rs
+++ b/src/transport_layer/transport_layer_builder.rs
@@ -1,27 +1,36 @@
+use crate::internals::StartingTcpSetup;
 use anyhow::Context;
 use anyhow::Result;
 use reserve_port::ReservedPort;
 use std::net::IpAddr;
 use std::net::SocketAddr;
-use tokio::net::TcpListener;
+use std::net::TcpListener as StdTcpListener;
+use tokio::net::TcpListener as TokioTcpListener;
 
-use crate::internals::StartingTcpSetup;
-
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TransportLayerBuilder {
-    ip: Option<IpAddr>,
-    port: Option<u16>,
+    kind: TransportLayerBuilderKind,
 }
 
 impl TransportLayerBuilder {
-    pub(crate) fn new(ip: Option<IpAddr>, port: Option<u16>) -> Self {
-        Self { ip, port }
+    pub(crate) fn from_ip_port(ip: Option<IpAddr>, port: Option<u16>) -> Self {
+        Self {
+            kind: TransportLayerBuilderKind::IpPort { ip, port },
+        }
+    }
+
+    pub(crate) fn from_tcp_listener(tcp_listener: StdTcpListener) -> Self {
+        Self {
+            kind: TransportLayerBuilderKind::TcpListener { tcp_listener },
+        }
     }
 
     pub(crate) fn tcp_listener_with_reserved_port(
         self,
-    ) -> Result<(SocketAddr, TcpListener, Option<ReservedPort>)> {
-        let setup = StartingTcpSetup::new(self.ip, self.port)
+    ) -> Result<(SocketAddr, TokioTcpListener, Option<ReservedPort>)> {
+        let setup = self
+            .kind
+            .into_tcp_setup()
             .context("Cannot create socket address for use")?;
 
         let socket_addr = setup.socket_addr;
@@ -31,8 +40,28 @@ impl TransportLayerBuilder {
         Ok((socket_addr, tcp_listener, maybe_reserved_port))
     }
 
-    pub fn tcp_listener(self) -> Result<TcpListener> {
+    pub fn tcp_listener(self) -> Result<TokioTcpListener> {
         let (_, tcp_listener, _) = self.tcp_listener_with_reserved_port()?;
         Ok(tcp_listener)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum TransportLayerBuilderKind {
+    IpPort {
+        ip: Option<IpAddr>,
+        port: Option<u16>,
+    },
+    TcpListener {
+        tcp_listener: StdTcpListener,
+    },
+}
+
+impl TransportLayerBuilderKind {
+    fn into_tcp_setup(self) -> Result<StartingTcpSetup> {
+        match self {
+            Self::IpPort { ip, port } => StartingTcpSetup::from_ip_port(ip, port),
+            Self::TcpListener { tcp_listener } => StartingTcpSetup::from_tcp_listener(tcp_listener),
+        }
     }
 }

--- a/tests/test-transport-http.rs
+++ b/tests/test-transport-http.rs
@@ -1,0 +1,39 @@
+use axum::Router;
+use axum::routing::get;
+use reserve_port::ReservedSocketAddr;
+use std::net::TcpListener;
+use axum_test::TestServer;
+
+#[tokio::test]
+async fn it_should_start_a_http_test_server_with_a_tcp_listener() {
+    async fn get_ping() -> &'static str {
+        "pong!"
+    }
+
+    // Build an application with a route.
+    let app = Router::new().route("/ping", get(get_ping));
+
+    // Reserve an address
+    let reserved_address = ReservedSocketAddr::reserve_random_socket_addr().unwrap();
+    let ip = reserved_address.ip();
+    let port = reserved_address.port();
+
+    let tcp_listener = TcpListener::bind(&reserved_address).unwrap();
+
+    // Run the server.
+    let server = TestServer::builder()
+        .http_transport_with_tcp_listener(tcp_listener)
+        .expect_success_by_default()
+        .build(app);
+
+    // Get the request normally.
+    server.get(&"/ping").await.assert_text("pong!");
+
+    // Get the request.
+    let absolute_url = format!("http://{ip}:{port}/ping");
+    let response = server.get(&absolute_url).await;
+
+    response.assert_text(&"pong!");
+    let request_path = response.request_url();
+    assert_eq!(request_path.to_string(), format!("http://{ip}:{port}/ping"));
+}


### PR DESCRIPTION
# Changes

 * Add support for creating a `TestServer` from a bound `TcpListener`.
 * Remove `Eq` from `Transport`.

Implements #203 