### PR TITLE
feat: add maybe_ versions of web socket receiving code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "21.1.0"
+version = "22.0.0"
 rust-version = "1.89"
 edition = "2024"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "22.0.0"
+version = "22.0.0-rc.1"
 rust-version = "1.89"
 edition = "2024"
 license = "MIT"

--- a/examples/websocket-chat/main.rs
+++ b/examples/websocket-chat/main.rs
@@ -30,7 +30,9 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio::spawn;
 use tokio::sync::RwLock;
+use tokio::time::sleep;
 
 #[cfg(test)]
 use axum_test::TestServer;
@@ -110,12 +112,12 @@ async fn handle_chat(socket: WebSocket, username: String, state: SharedAppState)
                 }
             }
 
-            ::tokio::time::sleep(Duration::from_millis(10)).await;
+            sleep(Duration::from_millis(10)).await;
         }
     });
 
     // This second task will receive messages from client and print them on server console
-    let mut recv_task = tokio::spawn(async move {
+    let mut recv_task = spawn(async move {
         while let Some(Ok(message)) = receiver.next().await {
             let raw_text = message
                 .into_text()

--- a/src/internals/websockets/test_response_websocket.rs
+++ b/src/internals/websockets/test_response_websocket.rs
@@ -1,8 +1,10 @@
 use crate::transport_layer::TransportLayerType;
 use hyper::upgrade::OnUpgrade;
+use std::time::Duration;
 
 #[derive(Debug, Clone)]
 pub struct TestResponseWebSocket {
     pub maybe_on_upgrade: Option<OnUpgrade>,
     pub transport_type: TransportLayerType,
+    pub receive_timeout: Duration,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! Create a [`TestServer`] running your Axum [`Router`](::axum::Router):
 //!
 //! ```rust
-//! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+//! # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 //! #
 //! use axum::Router;
 //! use axum::extract::Json;
@@ -42,7 +42,7 @@
 //! Then make requests against it:
 //!
 //! ```rust
-//! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+//! # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 //! #
 //! # use axum::Router;
 //! # use axum::extract::Json;
@@ -75,7 +75,7 @@
 //! identical for Actix Web.
 //!
 //! ```rust
-//! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+//! # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 //! use actix_web::App;
 //! use actix_web::HttpResponse;
 //! use actix_web::web;

--- a/src/multipart/mod.rs
+++ b/src/multipart/mod.rs
@@ -7,7 +7,7 @@
 //! # Simple example
 //!
 //! ```rust
-//! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+//! # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 //! #
 //! use axum::Router;
 //! use axum_test::TestServer;
@@ -30,7 +30,7 @@
 //! # Sending byte parts
 //!
 //! ```rust
-//! # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+//! # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 //! #
 //! use axum::Router;
 //! use axum_test::TestServer;

--- a/src/multipart/part.rs
+++ b/src/multipart/part.rs
@@ -85,7 +85,7 @@ impl Part {
     /// Adds a header to be sent with the Part of this Multiform.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -61,7 +61,7 @@ pub(crate) use self::test_request_config::*;
 /// Once fully configured you send the request by awaiting the request object.
 ///
 /// ```rust
-/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// #
 /// # use axum::Router;
 /// # use axum_test::TestServer;
@@ -229,7 +229,7 @@ impl TestRequest {
     /// # Simple example
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -252,7 +252,7 @@ impl TestRequest {
     /// # Sending byte parts
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -393,7 +393,7 @@ impl TestRequest {
     /// # Sending a body of parameters using `json!`
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -415,7 +415,7 @@ impl TestRequest {
     /// # Sending a body of parameters with Serde
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -444,7 +444,7 @@ impl TestRequest {
     /// # Sending a list of parameters
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -481,7 +481,7 @@ impl TestRequest {
     /// such as for the many versions of query param arrays.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -515,7 +515,7 @@ impl TestRequest {
     /// Adds a header to be sent with this request.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -584,7 +584,7 @@ impl TestRequest {
     /// then this will panic.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Json;
     /// use axum::Router;

--- a/src/test_request.rs
+++ b/src/test_request.rs
@@ -663,6 +663,7 @@ impl TestRequest {
             crate::internals::TestResponseWebSocket {
                 maybe_on_upgrade,
                 transport_type,
+                receive_timeout: self.config.ws_receive_timeout,
             }
         };
 

--- a/src/test_request/test_request_config.rs
+++ b/src/test_request/test_request_config.rs
@@ -8,6 +8,9 @@ use http::Method;
 use std::sync::Arc;
 use url::Url;
 
+#[cfg(feature = "ws")]
+use std::time::Duration;
+
 #[derive(Debug, Clone)]
 pub struct TestRequestConfig {
     pub atomic_cookie_jar: Arc<AtomicCrossCookieJar>,
@@ -21,4 +24,7 @@ pub struct TestRequestConfig {
     pub cookies: CookieJar,
     pub query_params: QueryParamsStore,
     pub headers: Vec<(HeaderName, HeaderValue)>,
+
+    #[cfg(feature = "ws")]
+    pub ws_receive_timeout: Duration,
 }

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -46,7 +46,7 @@ use crate::internals::TestResponseWebSocket;
 /// will produce the response.
 ///
 /// ```rust
-/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// #
 /// use axum::Json;
 /// use axum::Router;
@@ -72,7 +72,7 @@ use crate::internals::TestResponseWebSocket;
 /// allow you to extract the underlying response content in different formats.
 ///
 /// ```rust
-/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// #
 /// # use axum::Json;
 /// # use axum::Router;
@@ -111,7 +111,7 @@ use crate::internals::TestResponseWebSocket;
 /// methods.
 ///
 /// ```rust
-/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// #
 /// use axum::Json;
 /// use axum::Router;
@@ -136,7 +136,7 @@ use crate::internals::TestResponseWebSocket;
 /// These methods all return `&self` to allow chaining:
 ///
 /// ```rust
-/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// #
 /// # use axum::*;
 /// # use axum_test::TestServer;
@@ -199,7 +199,7 @@ impl TestResponse {
     /// # Example
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Json;
     /// use axum::Router;
@@ -239,7 +239,7 @@ impl TestResponse {
     /// # Example
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Json;
     /// use axum::Router;
@@ -290,7 +290,7 @@ impl TestResponse {
     /// # Example
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum::routing::get;
@@ -341,7 +341,7 @@ impl TestResponse {
     /// # Example
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum::routing::get;
@@ -392,7 +392,7 @@ impl TestResponse {
     /// # Example
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Form;
     /// use axum::Router;
@@ -703,7 +703,7 @@ impl TestResponse {
     /// # Example
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -803,7 +803,7 @@ impl TestResponse {
     /// then this will panic. Failing the assertion.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum::extract::Json;
@@ -835,7 +835,7 @@ impl TestResponse {
     /// See that module for more information.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// # use axum::Router;
     /// # use axum::extract::Json;
@@ -887,7 +887,7 @@ impl TestResponse {
     /// wish to ignore.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum::extract::Json;
@@ -945,7 +945,7 @@ impl TestResponse {
     /// Read json file from given path and assert it with json response.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Json;
     /// use axum::routing::get;
@@ -1135,7 +1135,7 @@ impl TestResponse {
     /// Assert the status code is within the range given.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Json;
     /// use axum::routing::get;
@@ -1195,7 +1195,7 @@ impl TestResponse {
     /// Assert the status code is not within the range given.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Json;
     /// use axum::routing::get;

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -747,7 +747,7 @@ impl TestResponse {
             format!("Failed to upgrade connection for, for request {debug_request_format}")
         });
 
-        TestWebSocket::new(upgraded).await
+        TestWebSocket::new(upgraded, self.websockets.receive_timeout).await
     }
 
     /// This performs an assertion comparing the whole body of the response,

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -53,7 +53,7 @@ const DEFAULT_URL_ADDRESS: &str = "http://localhost";
 /// and pass in your application:
 ///
 /// ```rust
-/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// #
 /// use axum::Router;
 /// use axum::routing::get;
@@ -79,7 +79,7 @@ const DEFAULT_URL_ADDRESS: &str = "http://localhost";
 /// For example:
 ///
 /// ```rust
-/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// #
 /// use axum::Router;
 /// use axum::routing::get;
@@ -112,7 +112,7 @@ const DEFAULT_URL_ADDRESS: &str = "http://localhost";
 /// or **real http** networking for your service.
 ///
 /// ```rust
-/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// #
 /// use axum::Router;
 /// use axum::routing::get;
@@ -167,7 +167,7 @@ impl TestServer {
     /// To catch the error use [`TestServer::try_new`].
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum::routing::get;
@@ -362,7 +362,7 @@ impl TestServer {
     /// This expects a relative url to the `TestServer`.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -404,7 +404,7 @@ impl TestServer {
     /// # Example
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -448,7 +448,7 @@ impl TestServer {
     /// Using a `TypedPath` you can write build and test a route like below:
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Json;
     /// use axum::Router;
@@ -568,7 +568,7 @@ impl TestServer {
     /// # Example
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;
@@ -707,7 +707,7 @@ impl TestServer {
     /// Adds a header to be sent with all future requests built from this `TestServer`.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -37,6 +37,8 @@ use std::cell::OnceCell;
 
 mod server_shared_state;
 pub(crate) use self::server_shared_state::*;
+#[cfg(feature = "ws")]
+use std::time::Duration;
 
 const DEFAULT_URL_ADDRESS: &str = "http://localhost";
 
@@ -149,6 +151,9 @@ pub struct TestServer {
 
     #[cfg(feature = "reqwest")]
     maybe_reqwest_client: OnceCell<Client>,
+
+    #[cfg(feature = "ws")]
+    ws_receive_timeout: Duration,
 }
 
 impl TestServer {
@@ -271,6 +276,9 @@ impl TestServer {
 
             #[cfg(feature = "reqwest")]
             maybe_reqwest_client: Default::default(),
+
+            #[cfg(feature = "ws")]
+            ws_receive_timeout: config.web_socket_receive_timeout,
         })
     }
 
@@ -779,6 +787,9 @@ impl TestServer {
             full_request_url,
             query_params,
             headers,
+
+            #[cfg(feature = "ws")]
+            ws_receive_timeout: self.ws_receive_timeout,
         })
     }
 

--- a/src/test_server_builder.rs
+++ b/src/test_server_builder.rs
@@ -15,7 +15,7 @@ use std::net::TcpListener as StdTcpListener;
 /// # Creating a [`TestServer`]
 ///
 /// ```rust
-/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// #
 /// use axum::Router;
 /// use axum_test::TestServer;
@@ -131,7 +131,7 @@ impl TestServerBuilder {
     /// with can be passed to [`TestServer::new_with_config`].
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;

--- a/src/test_server_builder.rs
+++ b/src/test_server_builder.rs
@@ -7,6 +7,9 @@ use anyhow::Result;
 use std::net::IpAddr;
 use std::net::TcpListener as StdTcpListener;
 
+#[cfg(feature = "ws")]
+use std::time::Duration;
+
 /// A builder for [`TestServer`]. Inside is a [`TestServerConfig`],
 /// configured by each method, and then turn into a server by [`TestServerBuilder::build`].
 ///
@@ -88,6 +91,12 @@ impl TestServerBuilder {
 
     pub fn restrict_requests_with_http_scheme(mut self) -> Self {
         self.config.restrict_requests_with_http_scheme = true;
+        self
+    }
+
+    #[cfg(feature = "ws")]
+    pub fn web_socket_receive_timeout(mut self, timeout: Duration) -> Self {
+        self.config.web_socket_receive_timeout = timeout;
         self
     }
 

--- a/src/test_server_config.rs
+++ b/src/test_server_config.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 /// These can be passed to `TestServer::new_with_config`:
 ///
 /// ```rust
-/// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+/// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 /// #
 /// use axum::Router;
 /// use axum_test::TestServer;
@@ -106,7 +106,7 @@ impl TestServerConfig {
     /// with config passed in.
     ///
     /// ```rust
-    /// # async fn test() -> Result<(), Box<dyn ::std::error::Error>> {
+    /// # async fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// #
     /// use axum::Router;
     /// use axum_test::TestServer;

--- a/src/test_server_config.rs
+++ b/src/test_server_config.rs
@@ -5,6 +5,12 @@ use crate::internals::ErrorMessage;
 use crate::transport_layer::IntoTransportLayer;
 use anyhow::Result;
 
+#[cfg(feature = "ws")]
+use std::time::Duration;
+
+#[cfg(feature = "ws")]
+const DEFAULT_WEB_SOCKET_RECEIVE_TIMEOUT: Duration = Duration::from_millis(20);
+
 /// This is for customising the [`TestServer`](crate::TestServer) on construction.
 /// It implements [`Default`] to ease building.
 ///
@@ -92,6 +98,11 @@ pub struct TestServerConfig {
     ///
     /// This overrides the default 'best efforts' approach of requests.
     pub default_content_type: Option<String>,
+
+    /// Sets the maximum amount of time to wait
+    /// when the [`crate::TestWebSocket`] needs to receive a message.
+    #[cfg(feature = "ws")]
+    pub web_socket_receive_timeout: Duration,
 }
 
 impl TestServerConfig {
@@ -152,6 +163,9 @@ impl Default for TestServerConfig {
             expect_success_by_default: false,
             restrict_requests_with_http_scheme: false,
             default_content_type: None,
+
+            #[cfg(feature = "ws")]
+            web_socket_receive_timeout: DEFAULT_WEB_SOCKET_RECEIVE_TIMEOUT,
         }
     }
 }

--- a/src/test_server_config.rs
+++ b/src/test_server_config.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use std::time::Duration;
 
 #[cfg(feature = "ws")]
-const DEFAULT_WEB_SOCKET_RECEIVE_TIMEOUT: Duration = Duration::from_millis(20);
+const DEFAULT_WEB_SOCKET_RECEIVE_TIMEOUT: Duration = Duration::from_millis(30);
 
 /// This is for customising the [`TestServer`](crate::TestServer) on construction.
 /// It implements [`Default`] to ease building.

--- a/src/test_web_socket.rs
+++ b/src/test_web_socket.rs
@@ -229,7 +229,7 @@ impl TestWebSocket {
     }
 
     #[must_use]
-    pub async fn maybe_receive_message_within(&mut self, wait: Duration) -> Option<WsMessage> {
+    async fn maybe_receive_message_within(&mut self, wait: Duration) -> Option<WsMessage> {
         let maybe_message = timeout(wait, self.stream.next()).await.ok()??;
         let message =
             maybe_message.error_message("Failed to receive message from WebSocket stream");
@@ -240,6 +240,16 @@ impl TestWebSocket {
     pub async fn assert_receive_message(&mut self, expected: WsMessage) -> &mut Self {
         let received = self.receive_message().await;
         assert_eq!(expected, received);
+
+        self
+    }
+
+    pub async fn assert_receive_no_message(&mut self) -> &mut Self {
+        let maybe_received = self.maybe_receive_message().await;
+
+        if let Some(received) = maybe_received {
+            panic!("Expected no message to be received, received '{received:?}'");
+        }
 
         self
     }

--- a/src/test_web_socket.rs
+++ b/src/test_web_socket.rs
@@ -14,15 +14,20 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::fmt::Debug;
 use std::fmt::Display;
+use std::time::Duration;
+use tokio::time::timeout;
 use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::protocol::Role;
 
 #[cfg(feature = "pretty-assertions")]
 use pretty_assertions::assert_eq;
 
+const DEFAULT_RECEIVE_TIMEOUT: Duration = Duration::from_millis(30);
+
 #[derive(Debug)]
 pub struct TestWebSocket {
     stream: WebSocketStream<TokioIo<Upgraded>>,
+    receive_timeout: Duration,
 }
 
 impl TestWebSocket {
@@ -30,7 +35,20 @@ impl TestWebSocket {
         let upgraded_io = TokioIo::new(upgraded);
         let stream = WebSocketStream::from_raw_socket(upgraded_io, Role::Client, None).await;
 
-        Self { stream }
+        Self {
+            stream,
+            receive_timeout: DEFAULT_RECEIVE_TIMEOUT,
+        }
+    }
+
+    pub fn receive_timeout(&self) -> Duration {
+        self.receive_timeout
+    }
+
+    pub fn set_receive_timeout(&mut self, receive_timeout: Duration) -> &mut Self {
+        self.receive_timeout = receive_timeout;
+
+        self
     }
 
     pub async fn close(mut self) {
@@ -104,6 +122,15 @@ impl TestWebSocket {
     }
 
     #[must_use]
+    pub async fn maybe_receive_text(&mut self) -> Option<String> {
+        let maybe_message = self.maybe_receive_message().await;
+
+        maybe_message.map(|message| {
+            message_to_text(message).error_message("Failed to receive websocket response as text")
+        })
+    }
+
+    #[must_use]
     pub async fn receive_json<T>(&mut self) -> T
     where
         T: DeserializeOwned,
@@ -111,6 +138,18 @@ impl TestWebSocket {
         let bytes = self.receive_bytes().await;
         serde_json::from_slice::<T>(&bytes)
             .error_message_with_body("Failed to deserialize Json websocket response", &bytes)
+    }
+
+    #[must_use]
+    pub async fn maybe_receive_json<T>(&mut self) -> Option<T>
+    where
+        T: DeserializeOwned,
+    {
+        let bytes = self.maybe_receive_bytes().await?;
+        let value = serde_json::from_slice::<T>(&bytes)
+            .error_message_with_body("Failed to deserialize Json websocket response", &bytes);
+
+        Some(value)
     }
 
     #[cfg(feature = "yaml")]
@@ -124,6 +163,19 @@ impl TestWebSocket {
             .error_message_with_body("Failed to deserialize Yaml websocket response", &bytes)
     }
 
+    #[cfg(feature = "yaml")]
+    #[must_use]
+    pub async fn maybe_receive_yaml<T>(&mut self) -> Option<T>
+    where
+        T: DeserializeOwned,
+    {
+        let bytes = self.maybe_receive_bytes().await?;
+        let value = serde_yaml::from_slice::<T>(&bytes)
+            .error_message_with_body("Failed to deserialize Yaml websocket response", &bytes);
+
+        Some(value)
+    }
+
     #[cfg(feature = "msgpack")]
     #[must_use]
     pub async fn receive_msgpack<T>(&mut self) -> T
@@ -135,10 +187,32 @@ impl TestWebSocket {
             .error_message("Failed to deserialize MsgPack websocket response")
     }
 
+    #[cfg(feature = "msgpack")]
+    #[must_use]
+    pub async fn maybe_receive_msgpack<T>(&mut self) -> Option<T>
+    where
+        T: DeserializeOwned,
+    {
+        let received_bytes = self.maybe_receive_bytes().await?;
+        let value = rmp_serde::from_slice::<T>(&received_bytes)
+            .error_message("Failed to deserialize MsgPack websocket response");
+
+        Some(value)
+    }
+
     #[must_use]
     pub async fn receive_bytes(&mut self) -> Bytes {
         let message = self.receive_message().await;
         message_to_bytes(message).error_message("Failed to receive websocket response as bytes")
+    }
+
+    #[must_use]
+    pub async fn maybe_receive_bytes(&mut self) -> Option<Bytes> {
+        let message = self.maybe_receive_message().await?;
+        let bytes = message_to_bytes(message)
+            .error_message("Failed to receive websocket response as bytes");
+
+        Some(bytes)
     }
 
     #[must_use]
@@ -149,18 +223,25 @@ impl TestWebSocket {
     }
 
     #[must_use]
-    async fn maybe_receive_message(&mut self) -> Option<WsMessage> {
-        let maybe_message = self.stream.next().await;
+    pub async fn maybe_receive_message(&mut self) -> Option<WsMessage> {
+        self.maybe_receive_message_within(self.receive_timeout)
+            .await
+    }
 
-        match maybe_message {
-            None => None,
-            Some(message_result) => {
-                let message =
-                    message_result.error_message("Failed to receive message from WebSocket stream");
+    #[must_use]
+    pub async fn maybe_receive_message_within(&mut self, wait: Duration) -> Option<WsMessage> {
+        let maybe_message = timeout(wait, self.stream.next()).await.ok()??;
+        let message =
+            maybe_message.error_message("Failed to receive message from WebSocket stream");
 
-                Some(message)
-            }
-        }
+        Some(message)
+    }
+
+    pub async fn assert_receive_message(&mut self, expected: WsMessage) -> &mut Self {
+        let received = self.receive_message().await;
+        assert_eq!(expected, received);
+
+        self
     }
 
     pub async fn assert_receive_json<T>(&mut self, expected: &T) -> &mut Self
@@ -1026,6 +1107,195 @@ received:
     🦊
 "#,
             error_message
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_maybe_receive_message {
+    use super::*;
+    use crate::TestServer;
+    use axum::Router;
+    use axum::extract::WebSocketUpgrade;
+    use axum::extract::ws::Message;
+    use axum::extract::ws::WebSocket;
+    use axum::response::Response;
+    use axum::routing::get;
+    use pretty_assertions::assert_eq;
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    fn new_test_app() -> TestServer {
+        pub async fn route_get_websocket(ws: WebSocketUpgrade) -> Response {
+            async fn handle_messages(mut socket: WebSocket) {
+                while let Some(received_message) = socket.recv().await {
+                    let received = received_message.unwrap();
+                    let received_text = received.to_text().unwrap();
+
+                    if received_text == "send-message" {
+                        socket
+                            .send(Message::Text("this is a message".into()))
+                            .await
+                            .unwrap();
+                    }
+
+                    if received_text == "delayed-message" {
+                        sleep(Duration::from_millis(500)).await;
+
+                        socket
+                            .send(Message::Text("this is a delayed message".into()))
+                            .await
+                            .unwrap();
+                    }
+                }
+            }
+
+            ws.on_upgrade(move |socket| handle_messages(socket))
+        }
+
+        let app = Router::new().route(&"/ws", get(route_get_websocket));
+        TestServer::builder().http_transport().build(app)
+    }
+
+    #[tokio::test]
+    async fn it_should_return_a_message_when_it_is_received() {
+        let server = new_test_app();
+
+        let mut websocket = server.get_websocket(&"/ws").await.into_websocket().await;
+
+        websocket.send_text(&"send-message").await;
+
+        let maybe_message = websocket.maybe_receive_message().await;
+        assert_eq!(
+            Some(WsMessage::Text("this is a message".into())),
+            maybe_message
+        );
+    }
+
+    #[tokio::test]
+    async fn it_should_return_none_when_no_message() {
+        let server = new_test_app();
+
+        let mut websocket = server.get_websocket(&"/ws").await.into_websocket().await;
+
+        websocket.send_text(&"no-message").await;
+
+        let maybe_message = websocket.maybe_receive_message().await;
+        assert_eq!(None, maybe_message);
+    }
+
+    #[tokio::test]
+    async fn it_should_return_none_when_message_is_delayed() {
+        let server = new_test_app();
+
+        let mut websocket = server.get_websocket(&"/ws").await.into_websocket().await;
+
+        websocket.send_text(&"delayed-message").await;
+
+        let maybe_message = websocket.maybe_receive_message().await;
+        assert_eq!(None, maybe_message);
+
+        sleep(Duration::from_millis(500)).await;
+
+        let maybe_message = websocket.maybe_receive_message().await;
+        assert_eq!(
+            Some(WsMessage::Text("this is a delayed message".into())),
+            maybe_message
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_maybe_receive_message_within {
+    use super::*;
+    use crate::TestServer;
+    use axum::Router;
+    use axum::extract::WebSocketUpgrade;
+    use axum::extract::ws::Message;
+    use axum::extract::ws::WebSocket;
+    use axum::response::Response;
+    use axum::routing::get;
+    use pretty_assertions::assert_eq;
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    fn new_test_app() -> TestServer {
+        pub async fn route_get_websocket(ws: WebSocketUpgrade) -> Response {
+            async fn handle_messages(mut socket: WebSocket) {
+                while let Some(received_message) = socket.recv().await {
+                    let received = received_message.unwrap();
+                    let received_text = received.to_text().unwrap();
+
+                    if received_text == "send-message" {
+                        socket
+                            .send(Message::Text("this is a message".into()))
+                            .await
+                            .unwrap();
+                    }
+
+                    if received_text == "delayed-message" {
+                        sleep(Duration::from_millis(500)).await;
+
+                        socket
+                            .send(Message::Text("this is a delayed message".into()))
+                            .await
+                            .unwrap();
+                    }
+                }
+            }
+
+            ws.on_upgrade(move |socket| handle_messages(socket))
+        }
+
+        let app = Router::new().route(&"/ws", get(route_get_websocket));
+        TestServer::builder().http_transport().build(app)
+    }
+
+    #[tokio::test]
+    async fn it_should_return_a_message_when_it_is_received() {
+        let server = new_test_app();
+
+        let mut websocket = server.get_websocket(&"/ws").await.into_websocket().await;
+
+        websocket.send_text(&"send-message").await;
+
+        let maybe_message = websocket
+            .maybe_receive_message_within(Duration::from_millis(50))
+            .await;
+        assert_eq!(
+            Some(WsMessage::Text("this is a message".into())),
+            maybe_message
+        );
+    }
+
+    #[tokio::test]
+    async fn it_should_return_none_when_no_message() {
+        let server = new_test_app();
+
+        let mut websocket = server.get_websocket(&"/ws").await.into_websocket().await;
+
+        websocket.send_text(&"no-message").await;
+
+        let maybe_message = websocket
+            .maybe_receive_message_within(Duration::from_millis(50))
+            .await;
+        assert_eq!(None, maybe_message);
+    }
+
+    #[tokio::test]
+    async fn it_should_return_some_message_from_delayed_message() {
+        let server = new_test_app();
+
+        let mut websocket = server.get_websocket(&"/ws").await.into_websocket().await;
+
+        websocket.send_text(&"delayed-message").await;
+
+        let maybe_message = websocket
+            .maybe_receive_message_within(Duration::from_secs(1))
+            .await;
+        assert_eq!(
+            Some(WsMessage::Text("this is a delayed message".into())),
+            maybe_message
         );
     }
 }

--- a/src/test_web_socket.rs
+++ b/src/test_web_socket.rs
@@ -22,8 +22,17 @@ use tokio_tungstenite::tungstenite::protocol::Role;
 #[cfg(feature = "pretty-assertions")]
 use pretty_assertions::assert_eq;
 
-const DEFAULT_RECEIVE_TIMEOUT: Duration = Duration::from_millis(30);
-
+/// The client for testing sending messages to and from a web server
+/// over a WebSocket.
+///
+/// # On timeouts for receiving messages
+///
+/// All of the receive methods are built to expect a message within a
+/// set timeout. This timeout is to prevent blocking forever when waiting
+/// for a message that never arrives.
+///
+/// The timeout can be changed by setting [`Self::set_receive_timeout`].
+/// The default value is 20 milliseconds.
 #[derive(Debug)]
 pub struct TestWebSocket {
     stream: WebSocketStream<TokioIo<Upgraded>>,
@@ -31,20 +40,18 @@ pub struct TestWebSocket {
 }
 
 impl TestWebSocket {
-    pub(crate) async fn new(upgraded: Upgraded) -> Self {
+    pub(crate) async fn new(upgraded: Upgraded, receive_timeout: Duration) -> Self {
         let upgraded_io = TokioIo::new(upgraded);
         let stream = WebSocketStream::from_raw_socket(upgraded_io, Role::Client, None).await;
 
         Self {
             stream,
-            receive_timeout: DEFAULT_RECEIVE_TIMEOUT,
+            receive_timeout,
         }
     }
 
-    pub fn receive_timeout(&self) -> Duration {
-        self.receive_timeout
-    }
-
+    /// Overrides the max timeout to wait to see if a WS message has
+    /// been received.
     pub fn set_receive_timeout(&mut self, receive_timeout: Duration) -> &mut Self {
         self.receive_timeout = receive_timeout;
 
@@ -244,8 +251,15 @@ impl TestWebSocket {
         self
     }
 
+    /// Asserts no message is received within a timeout.
     pub async fn assert_receive_no_message(&mut self) -> &mut Self {
-        let maybe_received = self.maybe_receive_message().await;
+        self.assert_receive_no_message_within(self.receive_timeout)
+            .await
+    }
+
+    /// Asserts no message is received within the given timeout.
+    pub async fn assert_receive_no_message_within(&mut self, timeout: Duration) -> &mut Self {
+        let maybe_received = self.maybe_receive_message_within(timeout).await;
 
         if let Some(received) = maybe_received {
             panic!("Expected no message to be received, received '{received:?}'");

--- a/src/test_web_socket.rs
+++ b/src/test_web_socket.rs
@@ -32,7 +32,7 @@ use pretty_assertions::assert_eq;
 /// for a message that never arrives.
 ///
 /// The timeout can be changed by setting [`Self::set_receive_timeout`].
-/// The default value is 20 milliseconds.
+/// The default value is 30 milliseconds.
 #[derive(Debug)]
 pub struct TestWebSocket {
     stream: WebSocketStream<TokioIo<Upgraded>>,


### PR DESCRIPTION
# Changes

 * Adds `TestWebSocket::maybe_receive_message()`
 * Adds `TestWebSocket::maybe_receive_text()`
 * Adds `TestWebSocket::maybe_receive_json()`
 * Adds `TestWebSocket::maybe_receive_yaml()`
 * Adds `TestWebSocket::maybe_receive_msgpack()`
 * Adds `TestWebSocket::maybe_receive_bytes()`
 * Adds `TestWebSocket::assert_receive_message()`
 * Adds `TestWebSocket::assert_receive_no_message()`
 * Adds `TestServerBuilder::web_socket_receive_timeout()` -- to set the default timeout for waiting for web socket messages. Default is 20ms.

## Breaking change
 * All `TestWebSocket` receive functions will now timeout within 20 milliseconds if they didn't receive a message. Previously they would block forever until the stream is closed.

Implements #209 
