### PR TITLE
feat: add http query support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ bytesize = "2.4.0"
 cookie = "0.18.1"
 educe = { version = "0.6.0", default-features = false, features = ["Clone", "PartialEq"] }
 expect-json = "1.11.0"
-http = "1.4.2"
+http = "1.5.0"
 http-body-util = "0.1.3"
 hyper-util = { version = "0.1.20", features = ["client", "http1", "client-legacy"] }
 hyper = { version = "1.10.1", features = ["http1"] }

--- a/src/test_response.rs
+++ b/src/test_response.rs
@@ -3362,6 +3362,9 @@ mod test_request_method {
         let method = server.post("/").await.request_method();
         assert_eq!(Method::POST, method);
 
+        let method = server.query("/").await.request_method();
+        assert_eq!(Method::QUERY, method);
+
         let method = server.put("/").await.request_method();
         assert_eq!(Method::PUT, method);
 

--- a/src/test_server.rs
+++ b/src/test_server.rs
@@ -284,6 +284,11 @@ impl TestServer {
         self.method(Method::POST, path)
     }
 
+    /// Creates a HTTP QUERY request to the given path.
+    pub fn query(&self, path: &str) -> TestRequest {
+        self.method(Method::QUERY, path)
+    }
+
     /// Creates a HTTP PATCH request to the path.
     pub fn patch(&self, path: &str) -> TestRequest {
         self.method(Method::PATCH, path)

--- a/tests/test-transport-http.rs
+++ b/tests/test-transport-http.rs
@@ -1,8 +1,8 @@
 use axum::Router;
 use axum::routing::get;
+use axum_test::TestServer;
 use reserve_port::ReservedSocketAddr;
 use std::net::TcpListener;
-use axum_test::TestServer;
 
 #[tokio::test]
 async fn it_should_start_a_http_test_server_with_a_tcp_listener() {


### PR DESCRIPTION
# Changes

 *  Update to http 1.5.0, this adds support at that level for the new HTTP QUERY method that was recently added to the spec.
 * Add a function similar to {GET,POST,PATCH,...} to make creating QUERY requests easily.

