### PR TITLE
chore: bump version to 21.1.0 for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
-version = "21.0.0"
+version = "21.1.0"
 rust-version = "1.88"
 edition = "2024"
 license = "MIT"
@@ -59,23 +59,23 @@ ws = ["axum/ws", "tokio/time", "dep:uuid", "dep:base64", "dep:tokio-tungstenite"
 
 [dependencies]
 axum = { version = "0.8.9", features = [] }
-anyhow = "1.0.102"
+anyhow = "1.0.104"
 bytes = "1.12.0"
 bytesize = "2.4.0"
-cookie = "0.18.1"
-educe = { version = "0.6.0", default-features = false, features = ["Clone", "PartialEq"] }
+cookie = "0.18.2"
+educe = { version = "0.7.6", default-features = false, features = ["Clone", "PartialEq"] }
 expect-json = "1.11.0"
 http = "1.5.0"
-http-body-util = "0.1.3"
+http-body-util = "0.1.5"
 hyper-util = { version = "0.1.20", features = ["client", "http1", "client-legacy"] }
 hyper = { version = "1.10.1", features = ["http1"] }
 mime = "0.3.17"
 rust-multipart-rfc7578_2 = "0.9.0"
 reserve-port = "2.5.0"
-serde = "1.0.228"
-serde_json = "1.0.150"
+serde = "1.0.229"
+serde_json = "1.0.151"
 serde_urlencoded = "0.7.1"
-tokio = { version = "1.52.3", features = ["rt"] }
+tokio = { version = "1.53.1", features = ["rt"] }
 tower = { version = "0.5.3", features = ["util", "make"] }
 url = "2.5.8"
 
@@ -92,16 +92,16 @@ rmp-serde = { version = "1.3.1", optional = true }
 axum-extra = { version = "0.12.6", optional = true, features = ["routing", "typed-routing"] }
 
 # WebSockets
-uuid = { version = "1.23.4", optional = true, features = ["v4"]}
-base64 = { version = "0.22.1", optional = true }
-futures-util = { version = "0.3.32", optional = true }
-tokio-tungstenite = { version = "0.29.0", optional = true }
+uuid = { version = "1.24.1", optional = true, features = ["v4"]}
+base64 = { version = "0.23.1", optional = true }
+futures-util = { version = "0.3.34", optional = true }
+tokio-tungstenite = { version = "0.30.0", optional = true }
 
 # Reqwest
 reqwest = { version = "0.13.4", optional = true, features = ["cookies", "json", "stream", "multipart"] }
 
 # Actix Web
-actix-web = { version = "4.14.0", optional = true }
+actix-web = { version = "4.14.1", optional = true }
 
 # Old Json Diff
 assert-json-diff = { version = "2.0.2", optional = true }
@@ -111,10 +111,10 @@ axum = { version = "0.8.9", features = ["multipart", "tokio", "ws"] }
 axum-extra = { version = "0.12.6", features = ["cookie", "typed-routing", "query"] }
 axum-msgpack = "0.5.0"
 axum-yaml = "0.5.0"
-futures = "0.3.32"
+futures = "0.3.34"
 futures-util = "0.3.32"
 insta = { version = "1.48.0", features = ["json"] }
-rand = "0.10.1"
+rand = "0.10.2"
 regex = "1.12.4"
 actix-ws = "0.4.0"
 serde-email = { version = "3.2.0", features = ["serde"] }


### PR DESCRIPTION
# Changes

 * Update dependencies to latest.
 * Bump version to 21.1.0

# Comments

This releases the addition of `Query` support for requests.
