### PR TITLE
chore: raise minimum rust to 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "axum-test"
 authors = ["Joseph Lenton <josephlenton@gmail.com>"]
 version = "21.1.0"
-rust-version = "1.88"
+rust-version = "1.89"
 edition = "2024"
 license = "MIT"
 description = "Easy E2E testing for Axum"


### PR DESCRIPTION
# Changes

 * Raise the minimum version of Rust needed to Rust 1.89. This is for an Educe update.
